### PR TITLE
feat: add SEO optimization with sitemap and OGP

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
@@ -12,6 +13,23 @@ export default defineConfig({
 			description: 'Official products and documentation for machina.gg',
 			social: [
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/machina-gg' }
+			],
+			head: [
+				// OGP 画像設定（TODO: Replace with actual brand image）
+				{
+					tag: 'meta',
+					attrs: {
+						property: 'og:image',
+						content: 'https://machina-gg.github.io/vision-products/og-image.png',
+					},
+				},
+				{
+					tag: 'meta',
+					attrs: {
+						name: 'twitter:image',
+						content: 'https://machina-gg.github.io/vision-products/og-image.png',
+					},
+				},
 			],
 			sidebar: [
 				{
@@ -36,5 +54,6 @@ export default defineConfig({
 				'./src/styles/custom.css',
 			],
 		}),
+		sitemap(),
 	],
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.0",
     "@astrojs/starlight": "^0.37.6",
     "astro": "^5.6.1",
     "sharp": "^0.34.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.0
+        version: 3.7.0
       '@astrojs/starlight':
         specifier: ^0.37.6
         version: 0.37.6(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3))

--- a/public/og-image.png
+++ b/public/og-image.png
@@ -1,0 +1,23 @@
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <!-- TODO: Replace with actual brand image -->
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <text x="600" y="280" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="white" text-anchor="middle">
+    machina.gg
+  </text>
+
+  <text x="600" y="360" font-family="Arial, sans-serif" font-size="32" fill="rgba(255,255,255,0.9)" text-anchor="middle">
+    Building innovative products
+  </text>
+
+  <text x="600" y="410" font-family="Arial, sans-serif" font-size="32" fill="rgba(255,255,255,0.9)" text-anchor="middle">
+    that enhance digital experiences
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- @astrojs/sitemap 統合を追加（sitemap.xml 自動生成）
- OGP 画像メタタグを astro.config.mjs に設定
- OGP 画像プレースホルダー（SVG）を public/og-image.png に配置
- 全ページに description が既に設定済みであることを確認

## Changes
- `pnpm add @astrojs/sitemap` でパッケージ追加
- `astro.config.mjs` に sitemap() integration 追加
- OGP メタタグ（og:image, twitter:image）を head に追加
- SVG 形式の OGP 画像プレースホルダーを作成（TODO: 実際のブランド画像に置き換える）

## Testing
- `pnpm build` が成功することを確認
- `dist/sitemap-index.xml` と `dist/sitemap-0.xml` が生成されることを確認
- 生成された HTML に OGP メタタグが含まれることを確認

Closes #9