### PR TITLE
feat: プロダクト別記事一覧ページ

### DIFF
--- a/src/content/docs/vision-focus/articles/index.mdx
+++ b/src/content/docs/vision-focus/articles/index.mdx
@@ -1,0 +1,25 @@
+---
+title: VisionFocus 関連記事
+description: VisionFocus に関する集中力・視力・デジタルウェルビーイングの記事一覧
+template: splash
+prev: false
+next: false
+---
+
+import ArticleList from '../../../../components/articles/ArticleList.astro';
+
+<div class="articles-page">
+  <div class="articles-header">
+    <p class="lp-section-heading">Articles</p>
+    <h1 class="articles-title">VisionFocus 関連記事</h1>
+    <p class="articles-subtitle">
+      VisionFocus に関する記事一覧
+    </p>
+  </div>
+
+  <ArticleList product="vision-focus" />
+
+  <div class="articles-back-link">
+    <a href="/articles/">全記事を見る →</a>
+  </div>
+</div>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -323,6 +323,22 @@ header.header {
 	margin: 0 auto;
 }
 
+.articles-back-link {
+	margin-top: 3rem;
+	text-align: center;
+}
+
+.articles-back-link a {
+	color: var(--sl-color-accent);
+	font-weight: 500;
+	text-decoration: none;
+	transition: opacity 0.2s ease;
+}
+
+.articles-back-link a:hover {
+	opacity: 0.8;
+}
+
 /* ==============================
    フォーカス可視スタイル（アクセシビリティ）
    ============================== */


### PR DESCRIPTION
## Summary
- `/vision-focus/articles/` ページを新規追加
- ArticleList に product="vision-focus" を渡してフィルタリング
- 全記事一覧（/articles/）へのリンク付き

Closes #29

## Test plan
- [ ] `/vision-focus/articles/` ページが表示される
- [ ] vision-focus タグの記事のみ表示される
- [ ] 全記事一覧へのリンクがある

🤖 Generated with [Claude Code](https://claude.com/claude-code)