### PR TITLE
feat: GitHub Actions CI/CD — main マージで GitHub Pages 自動デプロイ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,7 +11,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
@@ -22,27 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build site
-        run: pnpm build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
+      - name: Build with Astro
+        uses: withastro/action@v3
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- 既存の手動 pnpm/node セットアップを Astro 公式アクション (`withastro/action@v3`) に置き換え
- `withastro/action` がパッケージマネージャ検出（pnpm lockfile）・依存インストール・ビルド・アーティファクトアップロードを一括処理
- main への push + workflow_dispatch でトリガー

## Test plan
- [ ] YAML 構文が正しいこと（GitHub Actions タブでパースエラーがないこと）
- [ ] `withastro/action@v3` が pnpm を正しく検出すること
- [ ] main マージ後に GitHub Pages デプロイが実行されること

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)