### PR TITLE
fix: ヒーローセクションの情報密度とレイアウト改善

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,16 +5,16 @@ template: splash
 prev: false
 next: false
 hero:
-  tagline: プロダクトを、世界へ届けよう。
-  text: 集中力・生産性・デジタルウェルビーイングのためのアプリとツールを作っています。
+  tagline: 集中力を守り、生産性を高めるツール
+  text: 気が散るウェブサイトをブロックし、タイマーで集中を維持。あなたの「没頭する時間」を取り戻します。
   actions:
     - text: VisionFocus を見る
       link: /vision-focus/
       icon: right-arrow
       variant: primary
-    - text: GitHub
-      link: https://github.com/machina-gg
-      icon: github
+    - text: ドキュメントを読む
+      link: /docs/vision-focus/getting-started/
+      icon: open-book
       variant: minimal
 ---
 
@@ -22,7 +22,7 @@ import ProductCard from "../../components/hub/ProductCard.astro";
 
 <div class="hub-section">
   <p class="hub-section-title">Products</p>
-  <div class="hub-products-grid">
+  <div class="hub-products-center">
     <ProductCard
       name="VisionFocus"
       description="集中力を高め、視力を守る Chrome 拡張機能。ウェブサイトブロック・タイマー・ビジョンステートメントで毎日の生産性を底上げします。"

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -77,6 +77,7 @@ header.header {
   position: relative;
   isolation: isolate;
   text-align: center;
+  padding-bottom: 1rem !important;
 }
 
 [data-has-hero] .hero::before {
@@ -173,6 +174,12 @@ header.header {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 1.25rem;
+}
+
+/* カード1枚の場合のセンター配置 */
+.hub-products-center {
+  max-width: 480px;
+  margin: 0 auto;
 }
 
 /* ==============================


### PR DESCRIPTION
## Summary
- ヒーローパディングを縮小してファーストビューの情報密度を改善（PRODUCTSセクションが見切れるようスクロール誘導）
- キャッチコピーを「集中力を守り、生産性を高めるツール」に変更（ユーザー価値訴求）
- PRODUCTSカードをセンター配置に変更（1枚のカード用に `hub-products-center` クラス追加）
- ヒーローの GitHub リンクを「ドキュメントを読む」CTAに差し替え

## Test plan
- [ ] ファーストビューで PRODUCTS セクションが見切れることを確認
- [ ] キャッチコピーが「集中力を守り、生産性を高めるツール」に更新されていることを確認
- [ ] サブテキストが「気が散るウェブサイトをブロックし、タイマーで集中を維持。あなたの「没頭する時間」を取り戻します。」に更新されていることを確認
- [ ] カードがセンター配置されていることを確認
- [ ] GitHub リンクが削除され、ドキュメントCTAに差し替えされていることを確認
- [ ] ビルドが正常に完了すること

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)