### PR TITLE
fix: フッター改行・外部リンク明示・記事カード高さ・機能カードリンク化の細かい UI 修正

### DIFF
--- a/src/components/articles/ArticleCard.astro
+++ b/src/components/articles/ArticleCard.astro
@@ -49,6 +49,7 @@ const formattedDate = publishedAt.toLocaleDateString('ja-JP', {
     color: var(--sl-color-text);
     text-decoration: none;
     transition: border-color 0.2s ease, transform 0.2s ease;
+    min-height: 12rem;
   }
 
   .article-card:hover {
@@ -81,6 +82,10 @@ const formattedDate = publishedAt.toLocaleDateString('ja-JP', {
     color: var(--sl-color-white);
     margin: 0;
     line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 
   .article-card-description {
@@ -88,5 +93,9 @@ const formattedDate = publishedAt.toLocaleDateString('ja-JP', {
     color: var(--vp-text-muted);
     margin: 0;
     line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 </style>

--- a/src/components/lp/FeatureCard.astro
+++ b/src/components/lp/FeatureCard.astro
@@ -5,9 +5,11 @@ interface Props {
   title: string;
   description: string;
   icon?: IconName | string;
+  href?: string;
 }
 
-const { title, description, icon } = Astro.props;
+const { title, description, icon, href } = Astro.props;
+const Tag = href ? 'a' : 'div';
 
 const ICON_PATHS: Record<IconName, string> = {
   block: `<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
@@ -31,7 +33,7 @@ const isNamedIcon = icon && icon in ICON_PATHS;
 const iconSvg = isNamedIcon ? ICON_PATHS[icon as IconName] : null;
 ---
 
-<div class="feature-card">
+<Tag class="feature-card" {...(href ? { href } : {})}>
   {icon && (
     <div class="feature-card-icon">
       {iconSvg
@@ -42,10 +44,11 @@ const iconSvg = isNamedIcon ? ICON_PATHS[icon as IconName] : null;
   )}
   <h3 class="feature-card-title">{title}</h3>
   <p class="feature-card-description">{description}</p>
-</div>
+</Tag>
 
 <style>
   .feature-card {
+    display: block;
     padding: 1.5rem;
     background: rgba(15, 23, 42, 0.6);
     backdrop-filter: blur(8px);
@@ -55,6 +58,9 @@ const iconSvg = isNamedIcon ? ICON_PATHS[icon as IconName] : null;
     transition: border-color 0.25s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.25s ease;
     position: relative;
     overflow: hidden;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
   }
 
   .feature-card::before {

--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -9,8 +9,7 @@ const currentYear = new Date().getFullYear();
       <div class="site-footer-brand">
         <a href="/" class="site-footer-logo">Vision Products</a>
         <p class="site-footer-tagline">
-          集中力・生産性・デジタルウェルビーイングのための<br />
-          アプリとツールを作っています。
+          集中力・生産性・デジタルウェルビーイングのためのアプリとツールを作っています。
         </p>
         <div class="site-footer-social">
           <a
@@ -121,6 +120,7 @@ const currentYear = new Date().getFullYear();
     color: var(--vp-text-muted);
     line-height: 1.7;
     margin: 0 0 1.25rem;
+    max-width: 22rem;
   }
 
   .site-footer-social {

--- a/src/components/overrides/Search.astro
+++ b/src/components/overrides/Search.astro
@@ -19,10 +19,11 @@ const isDocsSection = pathname.startsWith('/docs/');
       class="header-nav-cta"
       target="_blank"
       rel="noopener noreferrer"
+      title="Chrome Web Store（外部サイト）"
     >
       Install Free
-      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-        <path d="M2 8L8 2M8 2H4M8 2V6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+        <path d="M3 11L11 3M11 3H5.5M11 3V8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
   </nav>
@@ -45,10 +46,11 @@ const isDocsSection = pathname.startsWith('/docs/');
       class="header-nav-cta"
       target="_blank"
       rel="noopener noreferrer"
+      title="Chrome Web Store（外部サイト）"
     >
       Install Free
-      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-        <path d="M2 8L8 2M8 2H4M8 2V6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+        <path d="M3 11L11 3M11 3H5.5M11 3V8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
   </nav>

--- a/src/content/docs/vision-focus.mdx
+++ b/src/content/docs/vision-focus.mdx
@@ -58,21 +58,25 @@ import VisionFocusPricing from "../../components/lp/VisionFocusPricing.astro";
       title="ウェブサイトブロック"
       description="気が散るサイトをワンクリックでブロック。カスタムリストで自分専用の集中環境を構築できます。"
       icon="block"
+      href="/docs/vision-focus/blocking-websites/"
     />
     <FeatureCard
       title="20-20-20 タイマー"
       description="定期的な休憩リマインダーで目の疲れを軽減。スクリーンタイムを科学的にコントロールします。"
       icon="timer"
+      href="/docs/vision-focus/timers/"
     />
     <FeatureCard
       title="デイリービジョン"
       description="今日の目標を書き留めてブラウジング中も表示。モチベーションを保ち、ゴールに向かい続けます。"
       icon="vision"
+      href="/docs/vision-focus/vision-statements/"
     />
     <FeatureCard
       title="プライバシーファースト"
       description="すべてのデータはローカルに保存。外部サーバーへのデータ送信は一切なし。安心して使えます。"
       icon="privacy"
+      href="/docs/vision-focus/faq/"
     />
   </FeatureGrid>
 </section>


### PR DESCRIPTION
## Summary
- フッター説明文の `<br>` を削除し `max-width: 22rem` で自然な折り返しに変更
- Install Free の外部リンクアイコンを 10px→14px に拡大し、`title` 属性で「Chrome Web Store（外部サイト）」を表示
- 記事カードに `min-height: 12rem` と `line-clamp`（タイトル2行/説明3行）を適用して高さを統一
- FeatureCard に `href` prop を追加し、各機能カードを Docs ページにリンク
  - ウェブサイトブロック → `/docs/vision-focus/blocking-websites/`
  - 20-20-20 タイマー → `/docs/vision-focus/timers/`
  - デイリービジョン → `/docs/vision-focus/vision-statements/`
  - プライバシーファースト → `/docs/vision-focus/faq/`

## Test plan
- [ ] フッターの改行が自然になっていることを確認
- [ ] Install Free が外部リンクであることが分かりやすくなっていることを確認（アイコン拡大＋ツールチップ）
- [ ] 記事カードの高さが揃っていることを確認
- [ ] 機能カードクリックで Docs ページに遷移することを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)