### PR TITLE
feat: 記事ページに末尾 CTA・前後ナビゲーション・目次を追加

### DIFF
--- a/src/components/articles/ArticleCta.astro
+++ b/src/components/articles/ArticleCta.astro
@@ -1,0 +1,80 @@
+---
+// 記事末尾の CTA バナー — VisionFocus への誘導
+---
+
+<aside class="article-cta" aria-label="VisionFocus を試す">
+  <div class="article-cta-inner">
+    <p class="article-cta-label">VisionFocus</p>
+    <p class="article-cta-heading">集中力を高める Chrome 拡張機能</p>
+    <p class="article-cta-description">
+      ウェブサイトブロック・集中タイマー・ビジョンステートメントで、深い集中を実現します。
+    </p>
+    <a href="/vision-focus/" class="article-cta-button">VisionFocus を試してみる</a>
+  </div>
+</aside>
+
+<style>
+  .article-cta {
+    max-width: 42rem;
+    margin: 3rem auto 0;
+    padding: 0 1.5rem;
+  }
+
+  .article-cta-inner {
+    text-align: center;
+    padding: 2.5rem 2rem;
+    border-radius: 1rem;
+    border: 1px solid color-mix(in srgb, var(--sl-color-accent) 25%, transparent);
+    background:
+      linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--sl-color-accent) 8%, transparent),
+        color-mix(in srgb, var(--vf-purple, #8B5CF6) 6%, transparent)
+      );
+  }
+
+  .article-cta-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--sl-color-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin: 0 0 0.5rem;
+  }
+
+  .article-cta-heading {
+    font-size: 1.25rem;
+    font-weight: 800;
+    color: var(--sl-color-white);
+    margin: 0 0 0.75rem;
+    letter-spacing: -0.02em;
+  }
+
+  .article-cta-description {
+    font-size: 0.875rem;
+    color: var(--vp-text-muted);
+    line-height: 1.7;
+    margin: 0 0 1.5rem;
+    max-width: 36ch;
+    margin-inline: auto;
+  }
+
+  .article-cta-button {
+    display: inline-block;
+    padding: 0.625rem 1.5rem;
+    background: linear-gradient(135deg, #14B8A6, #0d9488);
+    color: white;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 20px rgba(20, 184, 166, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .article-cta-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 28px rgba(20, 184, 166, 0.45);
+    color: white;
+  }
+</style>

--- a/src/components/articles/ArticleNav.astro
+++ b/src/components/articles/ArticleNav.astro
@@ -1,0 +1,136 @@
+---
+// 記事末尾の前後ナビゲーション — publishedAt 降順で前後を判定
+import { getCollection } from 'astro:content';
+
+interface Props {
+  /** 現在の記事の publishedAt（Date） */
+  currentDate: Date;
+}
+
+const { currentDate } = Astro.props;
+
+// 全記事を publishedAt 降順で取得（新しい順）
+const allDocs = await getCollection('docs');
+const articles = allDocs
+  .filter((doc) => doc.data.publishedAt != null)
+  .map((doc) => ({
+    title: doc.data.title,
+    href: `/${doc.id}/`,
+    publishedAt: doc.data.publishedAt as Date,
+  }))
+  .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+
+// 現在の記事のインデックスを特定
+const currentIndex = articles.findIndex(
+  (a) => a.publishedAt.getTime() === currentDate.getTime(),
+);
+
+// 降順リストなので index-1 = より新しい記事、index+1 = より古い記事
+const newerArticle = currentIndex > 0 ? articles[currentIndex - 1] : null;
+const olderArticle = currentIndex < articles.length - 1 ? articles[currentIndex + 1] : null;
+---
+
+{(olderArticle || newerArticle) && (
+  <nav class="article-nav" aria-label="前後の記事">
+    <div class="article-nav-inner">
+      {olderArticle ? (
+        <a href={olderArticle.href} class="article-nav-link article-nav-prev">
+          <span class="article-nav-dir">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M10 12L6 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            前の記事
+          </span>
+          <span class="article-nav-title">{olderArticle.title}</span>
+        </a>
+      ) : (
+        <span />
+      )}
+
+      {newerArticle ? (
+        <a href={newerArticle.href} class="article-nav-link article-nav-next">
+          <span class="article-nav-dir">
+            次の記事
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="article-nav-title">{newerArticle.title}</span>
+        </a>
+      ) : (
+        <span />
+      )}
+    </div>
+  </nav>
+)}
+
+<style>
+  .article-nav {
+    max-width: 42rem;
+    margin: 2.5rem auto 0;
+    padding: 0 1.5rem;
+  }
+
+  .article-nav-inner {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    padding-top: 2rem;
+    border-top: 1px solid color-mix(in srgb, var(--sl-color-accent) 15%, transparent);
+  }
+
+  @media (max-width: 480px) {
+    .article-nav-inner {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .article-nav-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding: 1rem;
+    border: 1px solid color-mix(in srgb, var(--sl-color-accent) 15%, transparent);
+    border-radius: 0.75rem;
+    text-decoration: none;
+    color: var(--sl-color-text);
+    background: var(--sl-color-bg-nav);
+    transition: border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .article-nav-link:hover {
+    border-color: var(--sl-color-accent);
+    transform: translateY(-1px);
+    color: var(--sl-color-text);
+  }
+
+  .article-nav-next {
+    text-align: right;
+  }
+
+  .article-nav-dir {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--sl-color-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .article-nav-next .article-nav-dir {
+    justify-content: flex-end;
+  }
+
+  .article-nav-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--sl-color-white);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/components/articles/ArticleToc.astro
+++ b/src/components/articles/ArticleToc.astro
@@ -1,0 +1,106 @@
+---
+// 記事ページの目次コンポーネント（Starlight の「On this page」相当）
+// article-body 内の h2/h3 見出しからクライアントサイドで自動生成する
+---
+
+<nav class="article-toc" aria-label="目次" data-article-toc>
+  <div class="article-toc-inner">
+    <p class="article-toc-title">目次</p>
+    <ul class="article-toc-list" data-toc-list></ul>
+  </div>
+</nav>
+
+<script>
+  // article-body 内の h2/h3 から目次を生成
+  function buildToc() {
+    const toc = document.querySelector('[data-article-toc]');
+    const list = document.querySelector('[data-toc-list]');
+    const body = document.querySelector('.article-body');
+    if (!toc || !list || !body) return;
+
+    const headings = body.querySelectorAll('h2, h3');
+    if (headings.length === 0) {
+      // 見出しがなければ目次自体を非表示
+      (toc as HTMLElement).style.display = 'none';
+      return;
+    }
+
+    headings.forEach((heading) => {
+      // id がなければ生成
+      if (!heading.id) {
+        heading.id = heading.textContent
+          ?.trim()
+          .toLowerCase()
+          .replace(/\s+/g, '-')
+          .replace(/[^\w\u3000-\u9FFF\u4E00-\u9FFF\uF900-\uFAFF-]/g, '') ?? '';
+      }
+
+      const li = document.createElement('li');
+      li.className =
+        heading.tagName === 'H3'
+          ? 'article-toc-item article-toc-item--nested'
+          : 'article-toc-item';
+
+      const a = document.createElement('a');
+      a.href = `#${heading.id}`;
+      a.textContent = heading.textContent?.trim() ?? '';
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  }
+
+  buildToc();
+</script>
+
+<style>
+  .article-toc {
+    max-width: 42rem;
+    margin: 0 auto 2.5rem;
+    padding: 0 1.5rem;
+  }
+
+  .article-toc-inner {
+    padding: 1.25rem 1.5rem;
+    border: 1px solid color-mix(in srgb, var(--sl-color-accent) 15%, transparent);
+    border-radius: 0.75rem;
+    background: var(--sl-color-bg-nav);
+  }
+
+  .article-toc-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--sl-color-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin: 0 0 0.75rem;
+  }
+
+  .article-toc-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .article-toc-item :global(a) {
+    font-size: 0.8125rem;
+    color: var(--vp-text-muted);
+    text-decoration: none;
+    line-height: 1.5;
+    transition: color 0.15s ease;
+  }
+
+  .article-toc-item :global(a:hover) {
+    color: var(--sl-color-accent);
+  }
+
+  .article-toc-item--nested {
+    padding-left: 1rem;
+  }
+
+  .article-toc-item--nested :global(a) {
+    font-size: 0.75rem;
+  }
+</style>

--- a/src/content/docs/articles/20-20-20-rule-eye-health.mdx
+++ b/src/content/docs/articles/20-20-20-rule-eye-health.mdx
@@ -10,12 +10,17 @@ next: false
 ---
 
 import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../components/articles/ArticleNav.astro";
 
 <ArticleHeader
   title="20-20-20ルールで目の疲れを防ぐ — スクリーンから目を守る科学的方法"
   publishedAt={new Date("2026-02-17")}
   products={["vision-focus"]}
 />
+
+<ArticleToc />
 
 <div class="article-body">
 
@@ -102,3 +107,6 @@ import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
 _VisionFocus の 20-20-20 タイマーは、[Chrome Web Store](https://chrome.google.com/webstore) から無料でインストールできます。_
 
 </div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-02-17")} />

--- a/src/content/docs/articles/deep-work-introduction.mdx
+++ b/src/content/docs/articles/deep-work-introduction.mdx
@@ -10,12 +10,17 @@ next: false
 ---
 
 import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../components/articles/ArticleNav.astro";
 
 <ArticleHeader
   title="Deep Work（深い集中）入門 — 浅い作業から脱出して本当の生産性を手に入れる"
   publishedAt={new Date("2026-01-27")}
   products={["vision-focus"]}
 />
+
+<ArticleToc />
 
 <div class="article-body">
 
@@ -128,3 +133,6 @@ Deep Work は才能ではなく、**訓練によって高められるスキル**
 最初は30分の Deep Work セッションから始め、少しずつ伸ばしていきましょう。毎日の積み重ねが、数ヶ月後には「他の人が4時間かけてやることを2時間でこなせる」という圧倒的な差になって返ってきます。
 
 </div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-01-27")} />

--- a/src/content/docs/articles/digital-minimalism-focus.mdx
+++ b/src/content/docs/articles/digital-minimalism-focus.mdx
@@ -10,12 +10,17 @@ next: false
 ---
 
 import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../components/articles/ArticleNav.astro";
 
 <ArticleHeader
   title="デジタルミニマリズム — スマートフォンとの健全な距離感を作る"
   publishedAt={new Date("2026-02-24")}
   products={["vision-focus"]}
 />
+
+<ArticleToc />
 
 <div class="article-body">
 
@@ -128,3 +133,6 @@ iOSのスクリーンタイム・Androidのデジタルウェルビーイング�
 まずは今夜、充電器を寝室の外に出してみましょう。たったそれだけで、翌朝の頭の中がいかに静かか、実感できるはずです。
 
 </div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-02-24")} />

--- a/src/content/docs/articles/how-to-block-distracting-websites.mdx
+++ b/src/content/docs/articles/how-to-block-distracting-websites.mdx
@@ -10,12 +10,17 @@ next: false
 ---
 
 import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../components/articles/ArticleNav.astro";
 
 <ArticleHeader
   title="気が散るウェブサイトをブロックして集中力を取り戻す方法"
   publishedAt={new Date("2026-02-10")}
   products={["vision-focus"]}
 />
+
+<ArticleToc />
 
 <div class="article-body">
 
@@ -92,3 +97,6 @@ SNS や動画サービスは、ドーパミンを刺激するように設計さ�
 まずは最も時間を奪っているサイトを1つだけブロックしてみてください。小さな変化が大きな違いを生みます。
 
 </div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-02-10")} />

--- a/src/content/docs/articles/multitasking-myth.mdx
+++ b/src/content/docs/articles/multitasking-myth.mdx
@@ -10,12 +10,17 @@ next: false
 ---
 
 import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../components/articles/ArticleNav.astro";
 
 <ArticleHeader
   title="マルチタスクという神話 — 同時作業が生産性を40%下げる理由"
   publishedAt={new Date("2026-02-03")}
   products={["vision-focus"]}
 />
+
+<ArticleToc />
 
 <div class="article-body">
 
@@ -120,3 +125,6 @@ import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
 今日から1つだけ試してみてください。メールを閉じて、通知をオフにして、1時間だけ1つのタスクに集中する。その差を体感したとき、シングルタスクの威力を実感できるはずです。
 
 </div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-02-03")} />

--- a/src/content/docs/articles/pomodoro-technique-guide.mdx
+++ b/src/content/docs/articles/pomodoro-technique-guide.mdx
@@ -10,12 +10,17 @@ next: false
 ---
 
 import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../components/articles/ArticleNav.astro";
 
 <ArticleHeader
   title="ポモドーロテクニック完全ガイド — 25分で集中力を最大化する方法"
   publishedAt={new Date("2026-01-20")}
   products={["vision-focus"]}
 />
+
+<ArticleToc />
 
 <div class="article-body">
 
@@ -100,3 +105,6 @@ import ArticleHeader from "../../../components/articles/ArticleHeader.astro";
 「25分集中して5分休む」というシンプルなサイクルは、集中力を持続させながら、創造性と回復力も同時に高めます。まずは今日、タイマーをセットして最初の25分を試してみましょう。
 
 </div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-01-20")} />


### PR DESCRIPTION
## Summary
- 記事末尾に「VisionFocus を試してみる」CTAバナーコンポーネント（`ArticleCta`）を追加
- 記事末尾に前後記事ナビゲーションコンポーネント（`ArticleNav`）を追加（publishedAt 降順で前後判定）
- 記事ページに目次コンポーネント（`ArticleToc`）を追加（article-body 内の h2/h3 からクライアントサイドで自動生成）
- 全6記事の MDX ファイルに3コンポーネントを統合

## Test plan
- [ ] 各記事ページで末尾に CTA バナーが表示され、`/vision-focus/` へのリンクが機能することを確認
- [ ] 前後記事ナビゲーションが正しい記事へリンクしていることを確認（最新記事では「次の記事」なし、最古記事では「前の記事」なし）
- [ ] 目次が表示され、各リンクをクリックすると該当見出しにスクロールすることを確認
- [ ] モバイル表示でレイアウトが崩れないことを確認
- [ ] `astro build` がエラーなく完了することを確認

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)