### PR TITLE
feat: カスタムコンポーネントの i18n 対応 — 翻訳辞書 + ロケール分岐

### DIFF
--- a/src/components/articles/ArticleCard.astro
+++ b/src/components/articles/ArticleCard.astro
@@ -15,7 +15,10 @@ const PRODUCT_LABELS: Record<string, string> = {
   'vision-focus': 'VisionFocus',
 };
 
-const formattedDate = publishedAt.toLocaleDateString('ja-JP', {
+// 日付フォーマットをロケールに応じて切替
+const locale = Astro.currentLocale ?? 'ja';
+const dateLocale = locale === 'en' ? 'en-US' : 'ja-JP';
+const formattedDate = publishedAt.toLocaleDateString(dateLocale, {
   year: 'numeric',
   month: 'long',
   day: 'numeric',

--- a/src/components/articles/ArticleCta.astro
+++ b/src/components/articles/ArticleCta.astro
@@ -1,15 +1,39 @@
 ---
 // 記事末尾の CTA バナー — VisionFocus への誘導
+
+// ロケール判定と翻訳辞書
+const locale = Astro.currentLocale ?? 'ja';
+const prefix = locale === 'en' ? '/en' : '';
+
+const t = {
+  ja: {
+    ariaLabel: 'VisionFocus を試す',
+    heading: '集中力を高める Chrome 拡張機能',
+    description: 'ウェブサイトブロック・集中タイマー・ビジョンステートメントで、深い集中を実現します。',
+    button: 'VisionFocus を試してみる',
+  },
+  en: {
+    ariaLabel: 'Try VisionFocus',
+    heading: 'The Chrome Extension for Deep Focus',
+    description: 'Block distracting websites, use focus timers, and set vision statements to achieve deep focus.',
+    button: 'Try VisionFocus',
+  },
+}[locale] ?? {
+  ariaLabel: 'VisionFocus を試す',
+  heading: '集中力を高める Chrome 拡張機能',
+  description: 'ウェブサイトブロック・集中タイマー・ビジョンステートメントで、深い集中を実現します。',
+  button: 'VisionFocus を試してみる',
+};
 ---
 
-<aside class="article-cta" aria-label="VisionFocus を試す">
+<aside class="article-cta" aria-label={t.ariaLabel}>
   <div class="article-cta-inner">
     <p class="article-cta-label">VisionFocus</p>
-    <p class="article-cta-heading">集中力を高める Chrome 拡張機能</p>
+    <p class="article-cta-heading">{t.heading}</p>
     <p class="article-cta-description">
-      ウェブサイトブロック・集中タイマー・ビジョンステートメントで、深い集中を実現します。
+      {t.description}
     </p>
-    <a href="/vision-focus/" class="article-cta-button">VisionFocus を試してみる</a>
+    <a href={`${prefix}/vision-focus/`} class="article-cta-button">{t.button}</a>
   </div>
 </aside>
 

--- a/src/components/articles/ArticleHeader.astro
+++ b/src/components/articles/ArticleHeader.astro
@@ -13,7 +13,19 @@ const PRODUCT_LABELS: Record<string, string> = {
   'vision-focus': 'VisionFocus',
 };
 
-const formattedDate = publishedAt.toLocaleDateString('ja-JP', {
+// ロケール判定
+const locale = Astro.currentLocale ?? 'ja';
+const prefix = locale === 'en' ? '/en' : '';
+
+// 翻訳辞書
+const t = {
+  ja: { backToArticles: '記事一覧へ' },
+  en: { backToArticles: 'Back to Articles' },
+}[locale] ?? { backToArticles: '記事一覧へ' };
+
+// 日付フォーマットをロケールに応じて切替
+const dateLocale = locale === 'en' ? 'en-US' : 'ja-JP';
+const formattedDate = publishedAt.toLocaleDateString(dateLocale, {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
@@ -21,11 +33,11 @@ const formattedDate = publishedAt.toLocaleDateString('ja-JP', {
 ---
 
 <header class="article-header">
-  <a href="/articles/" class="article-back-link">
+  <a href={`${prefix}/articles/`} class="article-back-link">
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path d="M10 12L6 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-    記事一覧へ
+    {t.backToArticles}
   </a>
 
   <h1 class="article-title">{title}</h1>

--- a/src/components/articles/ArticleList.astro
+++ b/src/components/articles/ArticleList.astro
@@ -9,10 +9,25 @@ interface Props {
 
 const { product, limit } = Astro.props;
 
+// ロケール判定
+const locale = Astro.currentLocale ?? 'ja';
+
+// 翻訳辞書
+const t = {
+  ja: { empty: '記事はまだありません。' },
+  en: { empty: 'No articles yet.' },
+}[locale] ?? { empty: '記事はまだありません。' };
+
 const allDocs = await getCollection('docs');
 
 const articles = allDocs
-  .filter((doc) => doc.data.publishedAt != null)
+  .filter((doc) => {
+    if (doc.data.publishedAt == null) return false;
+    // root locale(ja): id が 'en/' で始まらないもの
+    // en locale: id が 'en/' で始まるもの
+    if (locale === 'en') return doc.id.startsWith('en/');
+    return !doc.id.startsWith('en/');
+  })
   .map((doc) => ({
     title: doc.data.title,
     description: doc.data.description ?? '',
@@ -42,7 +57,7 @@ const displayed = limit ? filtered.slice(0, limit) : filtered;
     ))}
   </div>
 ) : (
-  <p class="article-list-empty">記事はまだありません。</p>
+  <p class="article-list-empty">{t.empty}</p>
 )}
 
 <style>

--- a/src/components/articles/ArticleNav.astro
+++ b/src/components/articles/ArticleNav.astro
@@ -9,10 +9,25 @@ interface Props {
 
 const { currentDate } = Astro.props;
 
-// 全記事を publishedAt 降順で取得（新しい順）
+// ロケール判定
+const locale = Astro.currentLocale ?? 'ja';
+
+// 翻訳辞書
+const t = {
+  ja: { olderArticle: '前の記事', newerArticle: '次の記事', navLabel: '前後の記事' },
+  en: { olderArticle: 'Older', newerArticle: 'Newer', navLabel: 'Article navigation' },
+}[locale] ?? { olderArticle: '前の記事', newerArticle: '次の記事', navLabel: '前後の記事' };
+
+// 全記事を publishedAt 降順で取得（現在のロケールの記事のみ）
 const allDocs = await getCollection('docs');
 const articles = allDocs
-  .filter((doc) => doc.data.publishedAt != null)
+  .filter((doc) => {
+    if (doc.data.publishedAt == null) return false;
+    // root locale(ja): id が 'en/' で始まらないもの
+    // en locale: id が 'en/' で始まるもの
+    if (locale === 'en') return doc.id.startsWith('en/');
+    return !doc.id.startsWith('en/');
+  })
   .map((doc) => ({
     title: doc.data.title,
     href: `/${doc.id}/`,
@@ -31,7 +46,7 @@ const olderArticle = currentIndex < articles.length - 1 ? articles[currentIndex 
 ---
 
 {(olderArticle || newerArticle) && (
-  <nav class="article-nav" aria-label="前後の記事">
+  <nav class="article-nav" aria-label={t.navLabel}>
     <div class="article-nav-inner">
       {olderArticle ? (
         <a href={olderArticle.href} class="article-nav-link article-nav-prev">
@@ -39,7 +54,7 @@ const olderArticle = currentIndex < articles.length - 1 ? articles[currentIndex 
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
               <path d="M10 12L6 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            前の記事
+            {t.olderArticle}
           </span>
           <span class="article-nav-title">{olderArticle.title}</span>
         </a>
@@ -50,7 +65,7 @@ const olderArticle = currentIndex < articles.length - 1 ? articles[currentIndex 
       {newerArticle ? (
         <a href={newerArticle.href} class="article-nav-link article-nav-next">
           <span class="article-nav-dir">
-            次の記事
+            {t.newerArticle}
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
               <path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>

--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -1,5 +1,35 @@
 ---
 const currentYear = new Date().getFullYear();
+
+// ロケール判定とテキスト翻訳辞書
+const locale = Astro.currentLocale ?? 'ja';
+const prefix = locale === 'en' ? '/en' : '';
+
+const t = {
+  ja: {
+    tagline: '集中力・生産性・デジタルウェルビーイングのためのアプリとツールを作っています。',
+    gettingStarted: 'はじめかた',
+    blockingWebsites: 'ウェブサイトブロック',
+    timers: 'タイマー機能',
+    privacy: 'プライバシーポリシー',
+    terms: '利用規約',
+  },
+  en: {
+    tagline: 'Building apps and tools for focus, productivity, and digital wellbeing.',
+    gettingStarted: 'Getting Started',
+    blockingWebsites: 'Blocking Websites',
+    timers: 'Timer Features',
+    privacy: 'Privacy Policy',
+    terms: 'Terms of Service',
+  },
+}[locale] ?? {
+  tagline: '集中力・生産性・デジタルウェルビーイングのためのアプリとツールを作っています。',
+  gettingStarted: 'はじめかた',
+  blockingWebsites: 'ウェブサイトブロック',
+  timers: 'タイマー機能',
+  privacy: 'プライバシーポリシー',
+  terms: '利用規約',
+};
 ---
 
 <footer class="site-footer">
@@ -7,9 +37,9 @@ const currentYear = new Date().getFullYear();
     <div class="site-footer-top">
       <!-- Brand -->
       <div class="site-footer-brand">
-        <a href="/" class="site-footer-logo">Vision Products</a>
+        <a href={`${prefix}/`} class="site-footer-logo">Vision Products</a>
         <p class="site-footer-tagline">
-          集中力・生産性・デジタルウェルビーイングのためのアプリとツールを作っています。
+          {t.tagline}
         </p>
         <div class="site-footer-social">
           <a
@@ -31,25 +61,25 @@ const currentYear = new Date().getFullYear();
         <div class="site-footer-col">
           <h3 class="site-footer-col-title">Products</h3>
           <ul class="site-footer-col-links">
-            <li><a href="/vision-focus/">VisionFocus</a></li>
+            <li><a href={`${prefix}/vision-focus/`}>VisionFocus</a></li>
           </ul>
         </div>
 
         <div class="site-footer-col">
           <h3 class="site-footer-col-title">VisionFocus</h3>
           <ul class="site-footer-col-links">
-            <li><a href="/docs/vision-focus/getting-started/">はじめかた</a></li>
-            <li><a href="/docs/vision-focus/blocking-websites/">ウェブサイトブロック</a></li>
-            <li><a href="/docs/vision-focus/timers/">タイマー機能</a></li>
-            <li><a href="/docs/vision-focus/faq/">FAQ</a></li>
+            <li><a href={`${prefix}/docs/vision-focus/getting-started/`}>{t.gettingStarted}</a></li>
+            <li><a href={`${prefix}/docs/vision-focus/blocking-websites/`}>{t.blockingWebsites}</a></li>
+            <li><a href={`${prefix}/docs/vision-focus/timers/`}>{t.timers}</a></li>
+            <li><a href={`${prefix}/docs/vision-focus/faq/`}>FAQ</a></li>
           </ul>
         </div>
 
         <div class="site-footer-col">
           <h3 class="site-footer-col-title">Legal</h3>
           <ul class="site-footer-col-links">
-            <li><a href="/legal/privacy/">プライバシーポリシー</a></li>
-            <li><a href="/legal/terms/">利用規約</a></li>
+            <li><a href={`${prefix}/legal/privacy/`}>{t.privacy}</a></li>
+            <li><a href={`${prefix}/legal/terms/`}>{t.terms}</a></li>
           </ul>
         </div>
       </div>

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -3,6 +3,10 @@ import ProductNav from '../shared/ProductNav.astro';
 
 const pathname = Astro.url.pathname;
 
+// ロケール判定
+const locale = Astro.currentLocale ?? 'ja';
+const prefix = locale === 'en' ? '/en' : '';
+
 const isVisionFocus = pathname.includes('/vision-focus');
 
 // LP ページ（docs/ legal/ changelog/ 以外の /vision-focus ページ）
@@ -14,15 +18,23 @@ const isProductLP =
 
 // 個別記事ページ（/articles/ 以下、ただし index は除く）
 const isIndividualArticle =
-  pathname.startsWith('/articles/') &&
+  (pathname.startsWith('/articles/') || pathname.startsWith('/en/articles/')) &&
   pathname !== '/articles/' &&
-  pathname !== '/articles';
+  pathname !== '/articles' &&
+  pathname !== '/en/articles/' &&
+  pathname !== '/en/articles';
+
+/* 翻訳辞書 */
+const t = {
+  ja: { overview: 'Overview', docs: 'Docs', privacy: 'Privacy', install: 'Install' },
+  en: { overview: 'Overview', docs: 'Docs', privacy: 'Privacy', install: 'Install' },
+}[locale] ?? { overview: 'Overview', docs: 'Docs', privacy: 'Privacy', install: 'Install' };
 
 const visionFocusLinks = [
-  { label: 'Overview', href: '/vision-focus/' },
-  { label: 'Docs',     href: '/docs/vision-focus/getting-started/' },
-  { label: 'Privacy',  href: '/legal/privacy/' },
-  { label: 'Install',  href: 'https://chrome.google.com/webstore', isExternal: true, isPrimary: true },
+  { label: t.overview, href: `${prefix}/vision-focus/` },
+  { label: t.docs,     href: `${prefix}/docs/vision-focus/getting-started/` },
+  { label: t.privacy,  href: `${prefix}/legal/privacy/` },
+  { label: t.install,  href: 'https://chrome.google.com/webstore', isExternal: true, isPrimary: true },
 ];
 ---
 

--- a/src/components/overrides/Search.astro
+++ b/src/components/overrides/Search.astro
@@ -1,27 +1,76 @@
 ---
 const pathname = Astro.url.pathname;
 
+// ロケール判定
+const locale = Astro.currentLocale ?? 'ja';
+const isEn = locale === 'en';
+const prefix = isEn ? '/en' : '';
+
 const isVisionFocusLP =
   pathname === '/vision-focus/' ||
-  pathname === '/vision-focus';
+  pathname === '/vision-focus' ||
+  pathname === '/en/vision-focus/' ||
+  pathname === '/en/vision-focus';
 
-const isArticlesSection = pathname.startsWith('/articles');
-const isDocsSection = pathname.startsWith('/docs/');
+const isArticlesSection = pathname.startsWith('/articles') || pathname.startsWith('/en/articles');
+const isDocsSection = pathname.startsWith('/docs/') || pathname.startsWith('/en/docs/');
+
+/* 翻訳辞書 */
+const t = {
+  ja: {
+    menuOpen: 'メニューを開く',
+    menuClose: 'メニューを閉じる',
+    navMenu: 'ナビゲーションメニュー',
+    navLabelLP: 'VisionFocus navigation',
+    navLabelSite: 'Site navigation',
+    articles: 'Articles',
+    docs: 'Docs',
+    features: 'Features',
+    pricing: 'Pricing',
+    installFree: 'Install Free',
+    chromeStoreTitle: 'Chrome Web Store（外部サイト）',
+  },
+  en: {
+    menuOpen: 'Open menu',
+    menuClose: 'Close menu',
+    navMenu: 'Navigation menu',
+    navLabelLP: 'VisionFocus navigation',
+    navLabelSite: 'Site navigation',
+    articles: 'Articles',
+    docs: 'Docs',
+    features: 'Features',
+    pricing: 'Pricing',
+    installFree: 'Install Free',
+    chromeStoreTitle: 'Chrome Web Store (external site)',
+  },
+}[locale] ?? {
+  menuOpen: 'メニューを開く',
+  menuClose: 'メニューを閉じる',
+  navMenu: 'ナビゲーションメニュー',
+  navLabelLP: 'VisionFocus navigation',
+  navLabelSite: 'Site navigation',
+  articles: 'Articles',
+  docs: 'Docs',
+  features: 'Features',
+  pricing: 'Pricing',
+  installFree: 'Install Free',
+  chromeStoreTitle: 'Chrome Web Store（外部サイト）',
+};
 
 /* ページ種別ごとのナビリンク定義 */
 const lpLinks = [
-  { label: 'Features', href: '/vision-focus/#features' },
-  { label: 'Pricing', href: '/vision-focus/#pricing' },
-  { label: 'Docs', href: '/docs/vision-focus/getting-started/' },
+  { label: t.features, href: `${prefix}/vision-focus/#features` },
+  { label: t.pricing, href: `${prefix}/vision-focus/#pricing` },
+  { label: t.docs, href: `${prefix}/docs/vision-focus/getting-started/` },
 ];
 
 const siteLinks = [
-  { label: 'Articles', href: '/articles/', isActive: isArticlesSection },
-  { label: 'Docs', href: '/docs/vision-focus/getting-started/', isActive: isDocsSection },
+  { label: t.articles, href: `${prefix}/articles/`, isActive: isArticlesSection },
+  { label: t.docs, href: `${prefix}/docs/vision-focus/getting-started/`, isActive: isDocsSection },
 ];
 
 const navLinks = isVisionFocusLP ? lpLinks : siteLinks;
-const navLabel = isVisionFocusLP ? 'VisionFocus navigation' : 'Site navigation';
+const navLabel = isVisionFocusLP ? t.navLabelLP : t.navLabelSite;
 ---
 
 <!-- デスクトップ用インラインナビ -->
@@ -39,9 +88,9 @@ const navLabel = isVisionFocusLP ? 'VisionFocus navigation' : 'Site navigation';
     class="header-nav-cta"
     target="_blank"
     rel="noopener noreferrer"
-    title="Chrome Web Store（外部サイト）"
+    title={t.chromeStoreTitle}
   >
-    Install Free
+    {t.installFree}
     <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
       <path d="M2 8L8 2M8 2H4M8 2V6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
@@ -49,12 +98,12 @@ const navLabel = isVisionFocusLP ? 'VisionFocus navigation' : 'Site navigation';
 </nav>
 
 <!-- モバイル用ハンバーガーメニュー -->
-<mobile-menu>
+<mobile-menu data-label-open={t.menuOpen} data-label-close={t.menuClose}>
   <button
     class="hamburger-btn"
     type="button"
     aria-expanded="false"
-    aria-label="メニューを開く"
+    aria-label={t.menuOpen}
     aria-controls="mobile-menu-panel"
   >
     <!-- ハンバーガーアイコン（3本線） -->
@@ -67,7 +116,7 @@ const navLabel = isVisionFocusLP ? 'VisionFocus navigation' : 'Site navigation';
     </svg>
   </button>
 
-  <div id="mobile-menu-panel" class="mobile-menu-panel" role="dialog" aria-label="ナビゲーションメニュー">
+  <div id="mobile-menu-panel" class="mobile-menu-panel" role="dialog" aria-label={t.navMenu}>
     <nav class="mobile-menu-nav" aria-label={navLabel}>
       {navLinks.map((link) => (
         <a
@@ -161,7 +210,8 @@ const navLabel = isVisionFocusLP ? 'VisionFocus navigation' : 'Site navigation';
     private open(): void {
       this.isOpen = true;
       this.btn.setAttribute('aria-expanded', 'true');
-      this.btn.setAttribute('aria-label', 'メニューを閉じる');
+      /* data 属性からロケール別ラベルを取得 */
+      this.btn.setAttribute('aria-label', this.dataset.labelClose ?? 'Close menu');
       this.panel.classList.add('is-open');
       this.syncThemeButtons();
     }
@@ -169,7 +219,8 @@ const navLabel = isVisionFocusLP ? 'VisionFocus navigation' : 'Site navigation';
     private close(): void {
       this.isOpen = false;
       this.btn.setAttribute('aria-expanded', 'false');
-      this.btn.setAttribute('aria-label', 'メニューを開く');
+      /* data 属性からロケール別ラベルを取得 */
+      this.btn.setAttribute('aria-label', this.dataset.labelOpen ?? 'Open menu');
       this.panel.classList.remove('is-open');
     }
 

--- a/src/components/overrides/SiteTitle.astro
+++ b/src/components/overrides/SiteTitle.astro
@@ -1,14 +1,18 @@
 ---
 const pathname = Astro.url.pathname;
 const isVisionFocus = pathname.includes('/vision-focus');
+
+// ロケール判定: 英語は /en/ プレフィックスを付与
+const locale = Astro.currentLocale ?? 'ja';
+const prefix = locale === 'en' ? '/en' : '';
 ---
 
 {isVisionFocus ? (
-  <a href="/vision-focus/" class="site-title site-title--product">
+  <a href={`${prefix}/vision-focus/`} class="site-title site-title--product">
     VisionFocus
   </a>
 ) : (
-  <a href="/" class="site-title site-title--hub">
+  <a href={`${prefix}/`} class="site-title site-title--hub">
     Vision Products
   </a>
 )}


### PR DESCRIPTION
## 概要

カスタムコンポーネントにインライン翻訳辞書パターンを導入し、英語ロケール（`/en/`）で英語テキストが表示されるようにする。

- `Astro.currentLocale` でロケール取得、フォールバックは `'ja'`
- 各コンポーネント内にインライン翻訳辞書（`ja` / `en`）を持つ最小構成
- 既存の日本語 URL・動作はすべて維持

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/components/overrides/Footer.astro` | タグライン・リンクラベルを翻訳辞書化。href にロケールプレフィックス追加 |
| `src/components/overrides/Search.astro` | ナビリンクラベル・aria-label・CTA テキストを翻訳辞書化。`data-*` 属性でスクリプトにロケール別ラベルを渡す |
| `src/components/overrides/PageTitle.astro` | ProductNav リンクを翻訳辞書化。英語記事ページ判定を `/en/` パス対応 |
| `src/components/overrides/SiteTitle.astro` | ロケールに応じた `href` プレフィックス（`/` or `/en/`） |
| `src/components/articles/ArticleHeader.astro` | 「記事一覧へ」翻訳、日付フォーマットのロケール切替（`ja-JP` / `en-US`）、href プレフィックス |
| `src/components/articles/ArticleNav.astro` | 「前の記事」「次の記事」翻訳、aria-label 翻訳、ロケール別記事フィルタ |
| `src/components/articles/ArticleCta.astro` | CTA テキスト全体を翻訳辞書化、href プレフィックス |
| `src/components/articles/ArticleList.astro` | ロケール別に記事をフィルタリング（`doc.id` プレフィックスで判定）、空メッセージ翻訳 |
| `src/components/articles/ArticleCard.astro` | 日付フォーマットのロケール切替（`ja-JP` / `en-US`） |

## 実装ポイント

### Search.astro の aria-label 動的更新

モバイルメニューの open/close で動的に変わる aria-label はスクリプト（Custom Element）内で設定されるため、`data-label-open` / `data-label-close` 属性を経由してロケール別ラベルを渡す。

### ArticleNav / ArticleList のロケールフィルタリング

英語記事は `doc.id` が `'en/'` で始まるため、プレフィックスで判定する。

## テスト

- `astro build` 正常完了（39 ページ生成）
- 日本語ルート・英語ルートの両方が生成されていることを確認

## 受け入れ条件チェック

- [x] 日本語ページ（`/`）で全コンポーネントが日本語表示のまま
- [x] 英語ページ（`/en/`）で全コンポーネントが英語表示
- [x] 記事一覧が現在のロケールの記事のみ表示する
- [x] リンクがロケールに応じた正しいパスを指す
- [x] 日付フォーマットがロケールに応じている
- [x] `astro build` が正常に完了する

Closes #50
Parent: #35