### PR TITLE
feat: 英語記事の初期セット作成（3記事）+ 記事一覧ページ

### DIFF
--- a/src/content/docs/en/articles/building-a-distraction-free-browser.mdx
+++ b/src/content/docs/en/articles/building-a-distraction-free-browser.mdx
@@ -1,0 +1,187 @@
+---
+title: "Building a Distraction-Free Browser Environment"
+description: "Your browser is your primary work tool — and your biggest source of distraction. Learn how to configure Chrome for deep focus with profiles, extensions, and intentional settings."
+publishedAt: 2026-02-10
+products:
+  - vision-focus
+template: splash
+prev: false
+next: false
+---
+
+import ArticleHeader from "../../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../../components/articles/ArticleNav.astro";
+
+<ArticleHeader
+  title="Building a Distraction-Free Browser Environment"
+  publishedAt={new Date("2026-02-10")}
+  products={["vision-focus"]}
+/>
+
+<ArticleToc />
+
+<div class="article-body">
+
+For most knowledge workers, the browser is simultaneously the most essential and most dangerous tool in their workflow. It provides access to every piece of information and communication platform needed to do the job — and to every distraction ever invented by the internet.
+
+The average person checks their smartphone 58 times per day, and a significant portion of those checks happen in the browser. News sites, social media, video platforms, and content aggregators are all designed by teams of engineers specifically to capture and hold your attention. You are competing against billion-dollar algorithms every time you open a new tab.
+
+The solution is not willpower. It is environment design: deliberately configuring your browser to make focus the default state and distraction the friction-laden exception.
+
+## Understanding the Distraction Loop
+
+Before building a better environment, it helps to understand why the current one fails. The distraction loop typically follows this pattern:
+
+1. A task becomes difficult, ambiguous, or uncomfortable
+2. The brain seeks relief from the discomfort
+3. The hand moves automatically toward the keyboard or mouse
+4. A distracting site is opened, often without conscious intention
+5. Engagement with stimulating content provides temporary relief
+6. Returning to the original task requires mental re-entry, costing 10–23 minutes of recovery time
+
+The key insight is step 3: the movement toward distraction is often automatic, not deliberate. The habit is deeply grooved, and the trigger is cognitive discomfort — which knowledge work produces constantly.
+
+To break this loop, you do not need to eliminate cognitive discomfort (you cannot). You need to insert enough friction between the impulse and the behavior that your conscious brain has time to intervene.
+
+## Step 1: Separate Work and Personal Browser Profiles
+
+Chrome profiles are one of the most underused productivity features in the browser. Each profile has its own:
+
+- Bookmarks and history
+- Saved passwords and autofill data
+- Extensions and settings
+- New tab page configuration
+
+The strategy: create a dedicated work profile that is configured strictly for focus, and a separate personal profile for everything else.
+
+**Setting up a work profile:**
+
+1. Click your profile avatar in the top-right corner of Chrome
+2. Select "Add" to create a new profile
+3. Name it "Work" and give it a distinct color
+4. Log in with a work Google account if you have one (optional)
+
+In your work profile:
+
+- Do not save passwords for any social media or entertainment sites
+- Remove shortcuts to distracting sites from the new tab page
+- Install only work-essential extensions
+- Disable notifications from all non-work sources
+
+In your personal profile:
+
+- Keep all personal bookmarks, social logins, and entertainment extensions
+- This is the browser you use outside of work hours
+
+The act of switching profiles introduces psychological friction. When you are in your work profile and you want to check a social site, you have to consciously switch profiles — a deliberate action that breaks the automatic loop.
+
+## Step 2: Configure Your New Tab Page
+
+The default Chrome new tab page shows your most visited sites, recent tabs, and often a news feed. This means that every new tab you open confronts you with a list of distracting destinations.
+
+Replace the default new tab with something intentional:
+
+**Option A: A blank page**
+Navigate to `chrome://newtab` settings or use an extension to show a plain, empty page. No links, no news, no suggestions — just a blank canvas. This removes all ambient distraction triggers.
+
+**Option B: A focus prompt**
+Display your top priority for the day on the new tab page. Being reminded of what you are supposed to be working on every time you open a tab is a surprisingly effective re-orientation mechanism.
+
+**Option C: A vision statement**
+A more powerful version of Option B: display a personal mission statement or long-term goal. The question "Is what I am about to do aligned with this goal?" creates a moment of reflection before the distraction takes hold.
+
+[VisionFocus](/en/vision-focus/) implements this as a core feature — your vision statement appears on every new tab page during focus sessions, providing a consistent north star as you work.
+
+## Step 3: Block Distracting Sites During Work Hours
+
+Even with a separated work profile and a focused new tab page, the address bar is still one keystroke away from any website. Site-blocking extensions add a harder barrier.
+
+**How website blockers work:**
+
+Site blockers intercept navigation requests to specified domains and either block them entirely or display an interstitial page before allowing access. This interstitial — the extra click, the delay, the reminder that you are about to be distracted — is often sufficient to break the automatic behavior.
+
+**Configuring effective blocking:**
+
+- Block your most visited distracting sites first (social media, news aggregators, video platforms)
+- Set blocking schedules aligned with your work hours — you want the blocks to be automatic, not something you need to remember to activate
+- Use a blocking mode that requires effort to override (not a simple one-click bypass)
+- Consider blocking at the category level rather than site-by-site: "all social media" is easier to maintain than a manually curated list
+
+**A starting list for most knowledge workers:**
+
+- Social media: Twitter/X, Instagram, Facebook, LinkedIn feed, TikTok, Reddit
+- News aggregators: Hacker News, Product Hunt, news sites
+- Video: YouTube (if not required for work), streaming services
+- Shopping: Amazon, any frequent shopping sites
+
+The goal is not to make these sites permanently inaccessible — just inaccessible during deep work sessions.
+
+## Step 4: Manage Browser Extensions
+
+Extensions are both valuable and dangerous. They add functionality, but each extension that runs on page load consumes resources and introduces potential distraction.
+
+**Extension hygiene principles:**
+
+- Audit your installed extensions quarterly. Remove any you have not used in 30 days.
+- In your work profile, keep only extensions that are directly required for work tasks.
+- Move all entertainment, social, and personal extensions to your personal profile.
+- Be wary of extensions that add notifications, badges, or feeds — these are attention capture mechanisms even when the extension serves a legitimate purpose.
+
+**Valuable focus-supporting extensions for a work profile:**
+
+- A website blocker with scheduling (essential)
+- A new tab focus page
+- An ad blocker (ads are attention-capture mechanisms; blocking them reduces ambient distraction load)
+- A reader mode extension for long articles (removes surrounding page furniture that competes for attention)
+
+## Step 5: Tame Browser Notifications
+
+Chrome can deliver push notifications from any website that requests permission. Over time, most users accumulate dozens of notification subscriptions — news sites, productivity apps, social platforms — that interrupt focus throughout the day.
+
+**Auditing and resetting notifications:**
+
+1. Go to `chrome://settings/content/notifications`
+2. Review the "Allowed to send notifications" list
+3. Remove all non-essential sites — be aggressive here
+4. Enable "Don't allow sites to send notifications" as the default for new sites
+
+**Alternative approach**: Block all notifications at the OS level during work hours using macOS Focus Mode or Windows Focus Assist. This mutes all app and browser notifications simultaneously without requiring per-site management.
+
+## Step 6: Manage Open Tabs
+
+Tab hoarding is another form of distraction. The accumulation of 20+ open tabs creates ambient cognitive load — each tab is an unresolved intention occupying mental bandwidth — and makes it easy to switch between tasks impulsively.
+
+**Tab management strategies:**
+
+- **One window per context**: Keep a single window open for your current deep work task. All other research or reference tabs go in a second window, minimized or moved to another desktop.
+- **Tab limit**: Some people find it helpful to impose a personal rule: no more than five tabs open at any time. When you need a new tab, you must close an existing one. This forces you to make conscious decisions about what deserves attention.
+- **Tab suspension**: Extensions that automatically suspend inactive tabs reduce memory usage and remove the visual temptation of tab titles competing for attention.
+- **Session management**: At the end of each workday, close all tabs intentionally. If you need to return to something, bookmark it. Starting the next day with a clean slate eliminates yesterday's unfinished browsing as a source of distraction.
+
+## Building a Focus Ritual Around Your Browser
+
+Individual settings are more effective when embedded in a ritual. Before each deep work session:
+
+1. Switch to your work browser profile
+2. Close all tabs unrelated to the current task
+3. Activate your website blocker for the duration of the session
+4. Open only the specific tabs you need for this task
+5. Silence all notifications
+6. Review your vision statement or task goal on the new tab page
+
+This ritual takes two to three minutes. It pays back in hours of uninterrupted focus.
+
+## The Bigger Picture
+
+A distraction-free browser environment is not about restriction — it is about intention. You are not making the internet worse; you are choosing when and how to engage with it.
+
+The sites you are blocking are designed to capture attention by default. By configuring your browser deliberately, you are reclaiming the right to allocate your attention according to your own values rather than the values of algorithm designers.
+
+Every deep work session protected by a well-configured browser environment is an investment in the quality of your thinking. Over months and years, that compound interest in focused time pays significant returns in the quality of the work you produce.
+
+</div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-02-10")} />

--- a/src/content/docs/en/articles/focus-techniques-for-remote-workers.mdx
+++ b/src/content/docs/en/articles/focus-techniques-for-remote-workers.mdx
@@ -1,0 +1,132 @@
+---
+title: "Focus Techniques for Remote Workers: Staying Sharp at Home"
+description: "Practical strategies to maintain deep focus while working from home. Learn how to design your environment, schedule, and browser to beat distractions."
+publishedAt: 2026-02-20
+products:
+  - vision-focus
+template: splash
+prev: false
+next: false
+---
+
+import ArticleHeader from "../../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../../components/articles/ArticleNav.astro";
+
+<ArticleHeader
+  title="Focus Techniques for Remote Workers: Staying Sharp at Home"
+  publishedAt={new Date("2026-02-20")}
+  products={["vision-focus"]}
+/>
+
+<ArticleToc />
+
+<div class="article-body">
+
+Remote work has become the norm for millions of knowledge workers worldwide. With that shift came a new challenge: the home environment is simply not designed for deep, sustained concentration. Your couch, your kitchen, and your family are all within reach — and so are your social feeds, streaming services, and every other digital distraction ever invented.
+
+The good news is that focus is not a fixed trait. It is a skill you can deliberately cultivate, and the remote environment — when designed correctly — can actually support deeper work than a noisy open-plan office.
+
+## Why Remote Work Makes Focus Harder
+
+### The Absence of Social Accountability
+
+In a traditional office, the mere presence of colleagues creates a subtle pressure to appear productive. At home, that social signal disappears. There is no one to notice when you have been scrolling for thirty minutes.
+
+Research in behavioral economics calls this effect "social facilitation." Without it, we rely entirely on internal motivation and structured habits, which are harder to sustain.
+
+### The Boundary Collapse
+
+At the office, the physical act of commuting signals your brain to shift into work mode. When your "commute" is a ten-second walk to the desk, the psychological boundary between personal and professional life blurs. This makes it harder to achieve the mental state required for deep work.
+
+### Unlimited Digital Access
+
+At home, you have unrestricted access to every website and app on your personal devices. Unlike corporate networks with content filtering, your home internet is wide open. The path of least resistance when a task feels difficult is to open a browser tab — and from there, the distraction spiral begins.
+
+## Technique 1: Design a Dedicated Work Zone
+
+Your environment shapes your behavior more than you might expect. The brain forms strong associations between physical spaces and mental states. A bed is for sleeping; a couch is for relaxing. If you always work from the kitchen table, your brain begins to associate that table with work.
+
+**Practical steps:**
+
+- Designate a specific desk or table exclusively for work. Even in a small apartment, a single corner can become your "deep work zone."
+- Keep this space clear of non-work items. A cluttered desk is a cluttered mind.
+- Use visual anchors: a plant, a specific lamp, or a minimal desk mat that signal "work mode" to your brain.
+- When the workday ends, physically leave the space and do not return until the next session.
+
+The goal is not aesthetics — it is conditioned response. The more consistently you work in one place, the faster your brain shifts into focus mode when you sit down there.
+
+## Technique 2: Build Transition Rituals
+
+Since you no longer have a commute to shift mental gears, you need to manufacture that transition artificially. A consistent pre-work ritual primes the brain for deep concentration.
+
+**Example morning ritual (15 minutes):**
+
+1. Make a cup of coffee or tea (a tactile, sensory anchor)
+2. Review your top three priorities for the day on paper
+3. Put on a focus playlist (ambient or instrumental music — lyrics compete with thought)
+4. Close all non-essential browser tabs and apps
+5. Set a 90-minute focus block timer
+
+The specifics matter less than the consistency. Do the same ritual every day, and your brain learns that this sequence precedes deep work. Over time, the ritual itself becomes a trigger for concentration.
+
+## Technique 3: Time-Block Your Calendar
+
+Ad-hoc task management — working on whatever feels urgent — is the enemy of deep focus. Time-blocking means assigning specific tasks to specific time slots in your calendar, treating those blocks as immovable appointments.
+
+**A simple time-block structure for remote workers:**
+
+| Time          | Activity                                      |
+| ------------- | --------------------------------------------- |
+| 9:00 – 12:00  | Deep work block (cognitively demanding tasks) |
+| 12:00 – 13:00 | Lunch + non-screen break                      |
+| 13:00 – 14:00 | Shallow work (email, Slack, admin)            |
+| 14:00 – 16:00 | Deep work block (second session)              |
+| 16:00 – 17:00 | Planning, review, end-of-day wrap-up          |
+
+Protect your morning blocks fiercely. Cognitive energy is highest in the first few hours after waking for most people. Spending that window on email is one of the costliest mistakes remote workers make.
+
+## Technique 4: Control Your Browser Environment
+
+The browser is both the primary tool of remote work and its greatest threat. Every website you could want to visit is a single address-bar keystroke away. Without friction, you will visit them when the work gets hard.
+
+Introducing deliberate friction breaks the automatic loop:
+
+- **Website blockers**: Tools that prevent access to specified sites during work hours force a conscious choice before you can be distracted. The extra step — acknowledging the block and choosing to override it — is often enough to break the impulse.
+- **Separate browser profiles**: Maintain one profile for deep work (minimal extensions, no saved passwords for social sites) and a separate profile for personal browsing. The act of switching profiles adds psychological friction.
+- **Minimalist start page**: Replace your default new-tab page with something neutral or purposeful — a blank page, a task list, or a motivating phrase — rather than a news feed that immediately competes for your attention.
+
+[VisionFocus](/en/vision-focus/) is designed specifically for this purpose. It blocks distracting websites during your focus sessions and surfaces your personal vision statement on the new tab page, reminding you why you are working in the first place.
+
+## Technique 5: Leverage the Pomodoro Principle
+
+The Pomodoro Technique — working in focused 25-minute sprints followed by 5-minute breaks — exploits two cognitive facts: attention is finite and rest is productive.
+
+You do not need to follow the 25/5 split rigidly. Research suggests that longer intervals (50–90 minutes of focused work followed by 15–20 minutes of genuine rest) may be more effective for deep cognitive tasks. Experiment to find your optimal interval.
+
+**The critical rule**: During your break, genuinely rest. Walk away from the screen, stretch, look out a window, or make a drink. Do not check social media — this is stimulation, not recovery, and you will return to work more depleted than when you left.
+
+## Technique 6: Manage Your Most Dangerous Distraction — Yourself
+
+External distractions get all the attention, but the internal ones are often worse. Boredom, anxiety, and procrastination are all self-generated. When a task feels difficult or uncertain, the mind seeks relief anywhere it can find it.
+
+**Strategies for internal distraction:**
+
+- **Clarify the next action**: Vague tasks breed procrastination. "Work on report" is paralyzing; "Write the introduction section, 300 words" is actionable. Always know exactly what you are doing before you sit down.
+- **Lower the activation energy**: If you are avoiding a task, make starting easier. Open the document, write a single sentence, then let momentum take over.
+- **Name the distraction**: When you notice yourself reaching for your phone, say internally: "I am bored and looking for stimulation." Simply naming the impulse reduces its power.
+- **Keep a distraction notepad**: When a random thought interrupts you ("I need to check that email / buy that thing / respond to that message"), write it on a physical notepad instead of acting on it. This empties the mental register without losing the thought.
+
+## Building a Sustainable System
+
+None of these techniques work in isolation. The most effective remote workers build a system: a dedicated space, a consistent ritual, a blocked calendar, a controlled browser, and strategies for internal resistance all working together.
+
+Start with one change this week. Design your workspace, block your top three distracting sites, or try a single time-blocked morning session. Build the habit before adding the next layer.
+
+The home environment will always have more potential distractions than the office. But it also offers something the office rarely can: the ability to design your entire environment to support the work that matters most.
+
+</div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-02-20")} />

--- a/src/content/docs/en/articles/index.mdx
+++ b/src/content/docs/en/articles/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Articles
+description: Practical insights on focus, productivity, and digital wellbeing.
+template: splash
+prev: false
+next: false
+---
+
+import ArticleList from "../../../../components/articles/ArticleList.astro";
+
+<div class="articles-page">
+  <div class="articles-header">
+    <p class="lp-section-heading">Articles</p>
+    <h1 class="articles-title">Focus & Productivity Articles</h1>
+    <p class="articles-subtitle">
+      Practical insights on digital wellbeing, focus, and eye health.
+    </p>
+  </div>
+
+  <ArticleList />
+</div>

--- a/src/content/docs/en/articles/science-of-digital-breaks.mdx
+++ b/src/content/docs/en/articles/science-of-digital-breaks.mdx
@@ -1,0 +1,137 @@
+---
+title: "The Science of Digital Breaks: Why Stepping Away Makes You More Productive"
+description: "Research shows that deliberate breaks from screens boost focus, creativity, and wellbeing. Learn what the science says and how to design breaks that actually restore your attention."
+publishedAt: 2026-02-15
+products:
+  - vision-focus
+template: splash
+prev: false
+next: false
+---
+
+import ArticleHeader from "../../../../components/articles/ArticleHeader.astro";
+import ArticleToc from "../../../../components/articles/ArticleToc.astro";
+import ArticleCta from "../../../../components/articles/ArticleCta.astro";
+import ArticleNav from "../../../../components/articles/ArticleNav.astro";
+
+<ArticleHeader
+  title="The Science of Digital Breaks: Why Stepping Away Makes You More Productive"
+  publishedAt={new Date("2026-02-15")}
+  products={["vision-focus"]}
+/>
+
+<ArticleToc />
+
+<div class="article-body">
+
+We live in a culture that glorifies busyness. The implicit assumption in most workplaces is that the person who works the longest, answers messages the fastest, and never seems to stop is the most productive member of the team. The science tells a very different story.
+
+Research on attention, cognitive performance, and creativity consistently shows that deliberate rest — including genuine breaks from digital devices — is not a luxury or a weakness. It is a biological requirement for sustained high performance.
+
+## The Attention Restoration Theory
+
+In the 1980s, environmental psychologists Rachel and Stephen Kaplan developed Attention Restoration Theory (ART). Their central insight was that human attention has two distinct modes.
+
+**Directed attention** is the effortful, voluntary focus we use for knowledge work — reading, writing, problem-solving, coding. It requires mental effort and fatigues over time, much like a muscle.
+
+**Involuntary attention** is the effortless, automatic engagement that occurs when we encounter inherently interesting stimuli — a crackling fire, a flowing stream, birdsong, a natural landscape. This mode does not fatigue; in fact, it restores directed attention.
+
+The implication is significant: exposure to natural environments (or any low-demand, restorative stimuli) actively replenishes the cognitive resources depleted by concentrated work. Staring at a second screen during your break — or scrolling social media — engages directed attention and prevents restoration.
+
+## What Happens to Your Brain During Focused Work
+
+Neuroscience has clarified the mechanism. When you engage in demanding cognitive tasks, the prefrontal cortex — the brain region responsible for executive function, decision-making, and impulse control — increases its metabolic activity significantly.
+
+Over time, this sustained activity leads to a buildup of glutamate in the synapses of the prefrontal cortex. High glutamate concentrations disrupt the efficient signaling between neurons, which manifests as decreased concentration, slower processing, increased errors, and difficulty maintaining motivation.
+
+Rest — particularly genuine disengagement from demanding stimuli — allows the brain to clear this glutamate buildup and restore optimal prefrontal function. A 2022 study published in _Current Biology_ by researchers at the Paris Brain Institute provided direct evidence for this glutamate accumulation model, showing that cognitive fatigue is a measurable neurochemical state, not merely a subjective feeling.
+
+## The Counterintuitive Truth About Productivity
+
+The prevailing productivity advice focuses almost entirely on working harder, longer, or more efficiently. Far less attention is paid to the recovery side of the equation.
+
+Elite performers in other domains understand this well. Olympic athletes, concert musicians, and chess grandmasters share a common training pattern: intensive practice blocks followed by genuine recovery. Sports science has long known that adaptation — the improvement in performance — happens during rest, not during the work itself.
+
+Cognitive performance follows the same pattern. A 2011 study published in _Cognition_ found that brief diversions from a task dramatically improved focus over prolonged periods, compared to taking no breaks at all. The researchers concluded that "deactivating and reactivating your goals allows you to stay focused."
+
+## Not All Breaks Are Equal
+
+Here is where most people go wrong: they take breaks, but they do not actually rest.
+
+During a typical "break," many knowledge workers:
+
+- Check email or Slack
+- Browse social media or news sites
+- Watch short video clips
+- Reply to text messages
+
+All of these activities share a critical property: they engage directed attention. They require the brain to process information, evaluate relevance, form responses, and regulate impulses (deciding to keep scrolling versus stop). This is stimulation, not restoration.
+
+**Restorative break activities:**
+
+- Walking, especially in a natural environment or quiet neighborhood
+- Looking out a window at a distant view (also beneficial for eye health — focusing on distant objects relaxes the ciliary muscles that strain during close-up screen work)
+- Brief meditation or controlled breathing exercises
+- Stretching, light movement, or exercise
+- Non-demanding conversation with another person
+- Making and drinking tea or coffee without a screen
+
+The common thread is low cognitive demand. You are not processing information; you are letting your mind wander or rest.
+
+## The 20-20-20 Rule: A Minimum Viable Break
+
+For knowledge workers who cannot afford long breaks during intensive periods, ophthalmologists recommend the 20-20-20 rule as a minimum: every 20 minutes, look at something at least 20 feet away for 20 seconds.
+
+This micro-break does not restore directed attention significantly — it is too short for that — but it meaningfully reduces digital eye strain. The ciliary muscles of the eye are held in constant tension when focusing at screen distance (typically 20–28 inches). Periodically releasing that tension reduces fatigue, headaches, and the blurred vision that accumulates over hours of screen work.
+
+For full cognitive restoration, longer breaks of 15–20 minutes every 90 minutes are more effective.
+
+## Designing a Break System
+
+Rather than waiting until you feel exhausted to take a break — at which point significant cognitive depletion has already occurred — design breaks into your schedule proactively.
+
+**A science-backed break structure for knowledge workers:**
+
+| Work interval    | Break duration | Break activity                           |
+| ---------------- | -------------- | ---------------------------------------- |
+| 90 minutes       | 15–20 minutes  | Walk or quiet rest away from screens     |
+| 25–50 minutes    | 5–10 minutes   | Look out window, stretch, light movement |
+| Every 20 minutes | 20 seconds     | 20-20-20 eye exercise                    |
+
+**Structural tips:**
+
+- Schedule breaks in your calendar as appointments, just as you would schedule meetings. This prevents the break from being "eaten" by the next task starting early.
+- Use a timer. When the timer ends, stop regardless of how you feel. By the time you notice fatigue, you are already impaired.
+- During breaks, physically leave the work environment if possible. The spatial change reinforces the mental shift.
+- Do not use the break to plan the next work session. Let your mind wander genuinely.
+
+## The Default Mode Network and Creativity
+
+There is a less intuitive benefit to genuine rest: creative insight.
+
+When the brain is not engaged in directed attention, a network of brain regions called the default mode network (DMN) becomes active. The DMN is associated with mind-wandering, autobiographical memory, future planning, and — crucially — the integration of disparate ideas.
+
+Many researchers now believe that the DMN is where creative insight happens. The famous "eureka moment" — the sudden connection between previously unrelated concepts — is thought to emerge from the background processing that occurs during mind-wandering, not from effortful directed thinking.
+
+This is why solutions to difficult problems often appear during a walk, in the shower, or just before sleep. You are not being less productive during these periods. Your brain is engaged in a different, often more valuable, form of cognitive work.
+
+The practical implication: do not feel guilty about staring into space. Schedule genuine downtime into your workday. You may find that the insights generated during those "unproductive" minutes more than compensate for the task time they replace.
+
+## Structuring Your Digital Diet
+
+Beyond scheduled breaks, a broader principle applies: your relationship with digital stimulation outside of working hours matters.
+
+Heavy social media use in the evenings, binge-watching content until late at night, and constantly monitoring notifications all deplete the attentional reserves you bring to the next day's deep work. Cognitive restoration happens primarily during sleep — but the quality of your pre-sleep state affects how effectively that restoration occurs.
+
+Consider a digital wind-down protocol in the evening: no stimulating screens in the hour before bed, a brief reflection on the day, and a deliberate transition to low-stimulation activities. The productivity gains the following morning are often immediate and measurable.
+
+## Conclusion
+
+The science of breaks converges on a clear message: focused work and genuine rest are not in competition — they are interdependent. You cannot sustain high cognitive performance without deliberate recovery any more than you can sprint without eventually walking.
+
+Design your workday to include real breaks. Protect them as fiercely as you protect your deep work sessions. And when you take a break, actually take it — step away from the screens, let your mind wander, and trust that the restoration happening in those minutes is as valuable as the work itself.
+
+</div>
+
+<ArticleCta />
+<ArticleNav currentDate={new Date("2026-02-15")} />

--- a/src/content/docs/en/vision-focus/articles/index.mdx
+++ b/src/content/docs/en/vision-focus/articles/index.mdx
@@ -1,0 +1,25 @@
+---
+title: VisionFocus Articles
+description: Articles on focus, eye health, and digital wellbeing related to VisionFocus.
+template: splash
+prev: false
+next: false
+---
+
+import ArticleList from "../../../../../components/articles/ArticleList.astro";
+
+<div class="articles-page">
+  <div class="articles-header">
+    <p class="lp-section-heading">Articles</p>
+    <h1 class="articles-title">VisionFocus Articles</h1>
+    <p class="articles-subtitle">
+      Articles on focus, eye health, and digital wellbeing with VisionFocus.
+    </p>
+  </div>
+
+<ArticleList product="vision-focus" />
+
+  <div class="articles-back-link">
+    <a href="/en/articles/">All Articles →</a>
+  </div>
+</div>


### PR DESCRIPTION
## 概要

英語圏ユーザー向けに3記事と記事一覧ページを新規作成しました。

Closes #53
Parent: #35

## 変更内容

### 新規ファイル

| ファイル | 概要 |
|---------|------|
| `src/content/docs/en/articles/index.mdx` | 英語記事一覧ページ（/en/articles/） |
| `src/content/docs/en/vision-focus/articles/index.mdx` | 英語 VisionFocus 記事一覧ページ（/en/vision-focus/articles/） |
| `src/content/docs/en/articles/focus-techniques-for-remote-workers.mdx` | リモートワーカー向け集中テクニック（~800 words） |
| `src/content/docs/en/articles/science-of-digital-breaks.mdx` | デジタル休憩の科学（~900 words） |
| `src/content/docs/en/articles/building-a-distraction-free-browser.mdx` | 気が散らないブラウザ環境構築（~1000 words） |

### 実装の要点

- 全記事の frontmatter: `publishedAt`, `products: [vision-focus]`, `template: splash`, `prev: false`, `next: false`
- ArticleHeader / ArticleToc / ArticleCta / ArticleNav コンポーネントを日本語記事と同じ構造で使用
- ArticleList のロケールフィルタ（#50）により、英語一覧ページには `en/` 配下の記事のみ表示される
- 日本語記事・ページは一切変更なし

## 動作確認

- [x] `astro build` 正常完了（42ページ生成）
- [x] `/en/articles/index.html` 生成確認
- [x] `/en/articles/focus-techniques-for-remote-workers/index.html` 生成確認
- [x] `/en/articles/science-of-digital-breaks/index.html` 生成確認
- [x] `/en/articles/building-a-distraction-free-browser/index.html` 生成確認
- [x] `/en/vision-focus/articles/index.html` 生成確認