### PR TITLE
feat: 英語版 LP・トップページ・Legal ページ作成

### DIFF
--- a/src/components/hub/ProductCard.astro
+++ b/src/components/hub/ProductCard.astro
@@ -6,9 +6,11 @@ interface Props {
   icon?: string;
   iconName?: string;
   badge?: string;
+  /** CTA ラベル（省略時は「詳しく見る」） */
+  ctaLabel?: string;
 }
 
-const { name, description, href, icon, iconName, badge } = Astro.props;
+const { name, description, href, icon, iconName, badge, ctaLabel = "詳しく見る" } = Astro.props;
 
 type IconName = 'vision-focus';
 
@@ -46,7 +48,7 @@ const resolvedIconSvg = iconName && iconName in NAMED_ICONS
     <p class="product-card-description">{description}</p>
   </div>
   <span class="product-card-cta">
-    詳しく見る
+    {ctaLabel}
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
       <path d="M3 7h8M7 3l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>

--- a/src/components/lp/VisionFocusPricing.astro
+++ b/src/components/lp/VisionFocusPricing.astro
@@ -1,10 +1,55 @@
 ---
-// Hardcoded VisionFocus pricing: Free vs Premium
+// VisionFocus 料金プランコンポーネント（日英 i18n 対応）
+const locale = Astro.currentLocale ?? "ja";
+const isEn = locale === "en";
+
+// 翻訳辞書
+const t = {
+  sectionTitle: isEn ? "Simple Pricing" : "シンプルな料金体系",
+  freePeriod: isEn ? "Free forever" : "永久無料",
+  freeTagline: isEn ? "For those who want to try it out" : "まずは試してみたい方へ",
+  freeCta: isEn ? "Get Started Free" : "無料で始める",
+  premiumBadge: isEn ? "Recommended" : "おすすめ",
+  premiumPeriod: isEn ? "/mo" : "/月",
+  premiumTagline: isEn ? "For those serious about focus" : "本気で集中したい方へ",
+  premiumCta: isEn ? "Start Premium" : "Premium を始める",
+  freeFeatures: isEn
+    ? [
+        "Website blocking (up to 10 sites)",
+        "Basic timer",
+        "Daily vision (1 entry)",
+      ]
+    : [
+        "ウェブサイトブロック（最大 10 サイト）",
+        "基本タイマー機能",
+        "デイリービジョン（1件）",
+      ],
+  freeOffFeatures: isEn
+    ? ["Custom themes", "Detailed reports", "Email support"]
+    : ["カスタムテーマ", "詳細レポート", "メールサポート"],
+  premiumFeatures: isEn
+    ? [
+        { text: "Website blocking (", strong: "unlimited", after: ")" },
+        { text: "Advanced timer options" },
+        { text: "Multiple visions & schedule" },
+        { text: "Full custom themes" },
+        { text: "Detailed reports & stats" },
+        { text: "Email support (within 24h)" },
+      ]
+    : [
+        { text: "ウェブサイトブロック（", strong: "無制限", after: "）" },
+        { text: "高度なタイマーオプション" },
+        { text: "複数ビジョン・スケジュール機能" },
+        { text: "フルカスタムテーマ" },
+        { text: "詳細レポート・統計" },
+        { text: "メールサポート（24h 以内）" },
+      ],
+};
 ---
 
 <section id="pricing" class="pricing-section">
   <p class="lp-section-heading">Pricing</p>
-  <h2 class="lp-section-title">シンプルな料金体系</h2>
+  <h2 class="lp-section-title">{t.sectionTitle}</h2>
 
   <div class="pricing-grid">
     <!-- Free tier -->
@@ -13,52 +58,32 @@
         <span class="pricing-tier-label">Free</span>
         <div class="pricing-price">
           <span class="pricing-amount">$0</span>
-          <span class="pricing-period">永久無料</span>
+          <span class="pricing-period">{t.freePeriod}</span>
         </div>
-        <p class="pricing-tagline">まずは試してみたい方へ</p>
+        <p class="pricing-tagline">{t.freeTagline}</p>
       </div>
 
       <ul class="pricing-features">
-        <li class="pricing-feature">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          ウェブサイトブロック（最大 10 サイト）
-        </li>
-        <li class="pricing-feature">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          基本タイマー機能
-        </li>
-        <li class="pricing-feature">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          デイリービジョン（1件）
-        </li>
-        <li class="pricing-feature pricing-feature--off">
-          <svg class="pricing-x" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M3 3l8 8M11 3L3 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
-          カスタムテーマ
-        </li>
-        <li class="pricing-feature pricing-feature--off">
-          <svg class="pricing-x" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M3 3l8 8M11 3L3 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
-          詳細レポート
-        </li>
-        <li class="pricing-feature pricing-feature--off">
-          <svg class="pricing-x" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M3 3l8 8M11 3L3 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
-          メールサポート
-        </li>
+        {t.freeFeatures.map((feature) => (
+          <li class="pricing-feature">
+            <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            {feature}
+          </li>
+        ))}
+        {t.freeOffFeatures.map((feature) => (
+          <li class="pricing-feature pricing-feature--off">
+            <svg class="pricing-x" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M3 3l8 8M11 3L3 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+            {feature}
+          </li>
+        ))}
       </ul>
 
       <a href="https://chrome.google.com/webstore" class="pricing-cta pricing-cta--free" target="_blank" rel="noopener noreferrer">
-        無料で始める
+        {t.freeCta}
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
           <path d="M3 7h8M7 3l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
@@ -67,58 +92,33 @@
 
     <!-- Premium tier -->
     <div class="pricing-card pricing-card--premium">
-      <span class="pricing-recommended-badge">おすすめ</span>
+      <span class="pricing-recommended-badge">{t.premiumBadge}</span>
 
       <div class="pricing-card-header">
         <span class="pricing-tier-label pricing-tier-label--premium">Premium</span>
         <div class="pricing-price">
           <span class="pricing-amount">$1.99</span>
-          <span class="pricing-period">/月</span>
+          <span class="pricing-period">{t.premiumPeriod}</span>
         </div>
-        <p class="pricing-tagline">本気で集中したい方へ</p>
+        <p class="pricing-tagline">{t.premiumTagline}</p>
       </div>
 
       <ul class="pricing-features">
-        <li class="pricing-feature pricing-feature--premium">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          ウェブサイトブロック（<strong>無制限</strong>）
-        </li>
-        <li class="pricing-feature pricing-feature--premium">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          高度なタイマーオプション
-        </li>
-        <li class="pricing-feature pricing-feature--premium">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          複数ビジョン・スケジュール機能
-        </li>
-        <li class="pricing-feature pricing-feature--premium">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          フルカスタムテーマ
-        </li>
-        <li class="pricing-feature pricing-feature--premium">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          詳細レポート・統計
-        </li>
-        <li class="pricing-feature pricing-feature--premium">
-          <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-            <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          メールサポート（24h 以内）
-        </li>
+        {t.premiumFeatures.map((feature) => (
+          <li class="pricing-feature pricing-feature--premium">
+            <svg class="pricing-check" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M2 7l3.5 3.5L12 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            {feature.strong
+              ? <>{feature.text}<strong>{feature.strong}</strong>{feature.after ?? ""}</>
+              : feature.text
+            }
+          </li>
+        ))}
       </ul>
 
       <a href="https://chrome.google.com/webstore" class="pricing-cta pricing-cta--premium" target="_blank" rel="noopener noreferrer">
-        Premium を始める
+        {t.premiumCta}
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
           <path d="M3 7h8M7 3l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>

--- a/src/content/docs/en/index.mdx
+++ b/src/content/docs/en/index.mdx
@@ -1,0 +1,35 @@
+---
+title: Vision Products
+description: Apps and tools built for focus, productivity, and digital wellbeing.
+template: splash
+prev: false
+next: false
+hero:
+  tagline: Tools to protect your focus and boost productivity
+  text: Block distracting websites and stay in the zone with timers. Reclaim your deep work time.
+  actions:
+    - text: Explore VisionFocus
+      link: /en/vision-focus/
+      icon: right-arrow
+      variant: primary
+    - text: Read Docs
+      link: /en/docs/vision-focus/getting-started/
+      icon: open-book
+      variant: minimal
+---
+
+import ProductCard from "../../../components/hub/ProductCard.astro";
+
+<div class="hub-section">
+  <p class="hub-section-title">Products</p>
+  <div class="hub-products-center">
+    <ProductCard
+      name="VisionFocus"
+      description="A Chrome extension that boosts focus and protects your eyes. Block websites, set timers, and write daily vision statements to maximize your daily productivity."
+      href="/en/vision-focus/"
+      iconName="vision-focus"
+      badge="Chrome Extension"
+      ctaLabel="Explore"
+    />
+  </div>
+</div>

--- a/src/content/docs/en/legal/privacy.md
+++ b/src/content/docs/en/legal/privacy.md
@@ -1,0 +1,101 @@
+---
+title: Privacy Policy
+description: Privacy Policy for the VisionFocus Chrome Extension
+---
+
+# Privacy Policy
+
+**Last updated: February 15, 2026**
+
+This Privacy Policy explains how VisionFocus ("we") handles information when you use the Chrome extension.
+
+## Information We Collect
+
+VisionFocus is designed with privacy at its core. We handle only the minimum information necessary to provide our service.
+
+### Local Data Storage
+
+All settings including blocked sites, timer settings, and vision statements are stored **on your device only** using Chrome's `chrome.storage.local` API. This includes:
+
+- URLs of blocked websites
+- Timer settings and user preferences
+- Daily vision statements
+- Extension settings
+
+**None of this data is ever transmitted outside your device.**
+
+### Payment Information
+
+If you purchase VisionFocus Premium:
+
+- Payments are processed by **Stripe** through ExtensionPay
+- We never store or view your credit card information
+- Card information is handled according to Stripe's Privacy Policy: [https://stripe.com/privacy](https://stripe.com/privacy)
+- We only receive notification that payment was completed
+
+### Usage Analytics
+
+VisionFocus **does not use** Google Analytics or any other analytics services. We do not collect usage statistics, browsing behavior, or telemetry data.
+
+## How We Use Information
+
+Since all data is stored locally:
+
+- We cannot access your block list
+- We cannot view your vision statements
+- We cannot track your browsing behavior
+- We do not share information with third parties (because we don't collect it)
+
+## Data Security
+
+Your data is protected by Chrome's built-in security mechanisms:
+
+- Local storage is sandboxed within Chrome's extension system
+- No data transmission means no interception risk
+- Data security is equivalent to your Chrome browser profile
+
+## Third-Party Services
+
+### ExtensionPay (Stripe)
+
+Premium subscriptions use ExtensionPay, which integrates with Stripe to process payments. When you make a payment:
+
+- Stripe collects and processes your payment information
+- ExtensionPay verifies subscription status
+- We only receive notification that payment was completed
+
+For more details, see:
+
+- Stripe Privacy Policy: [https://stripe.com/privacy](https://stripe.com/privacy)
+- ExtensionPay Privacy Policy: [https://extensionpay.com/privacy](https://extensionpay.com/privacy)
+
+## Your Rights
+
+Since all data is stored on your device, you have full control:
+
+- **Access**: All data can be viewed from the extension's settings
+- **Deletion**: Uninstalling the extension will also delete all local data
+- **Export**: You can manually copy settings at any time
+- **Modification**: Edit or delete at any time through the extension interface
+
+## Age Restrictions
+
+VisionFocus is not intended for children under 13. We do not intentionally collect personal information from children under 13.
+
+## Policy Changes
+
+This Privacy Policy may be updated from time to time. For significant changes, we will notify you by:
+
+- Updating the "Last updated" date
+- Showing a notification in the extension (for major changes)
+
+## Contact Us
+
+For questions about this Privacy Policy:
+
+- GitHub Issues: [https://github.com/machina-gg/vision-focus/issues](https://github.com/machina-gg/vision-focus/issues)
+- Email: privacy@machina.gg
+
+## Summary
+
+VisionFocus stores all data on your device only. We do not collect, transmit, or share personal information. Payments are processed securely by Stripe. Your privacy is our top priority.

--- a/src/content/docs/en/legal/terms.md
+++ b/src/content/docs/en/legal/terms.md
@@ -1,0 +1,193 @@
+---
+title: Terms of Service
+description: Terms of Service for the VisionFocus Chrome Extension
+---
+
+# Terms of Service
+
+**Last updated: February 15, 2026**
+
+Please read these Terms of Service ("Terms") carefully before using the VisionFocus Chrome extension ("Service", "Extension"). The extension is operated by machina.gg ("we", "us", "our").
+
+## Acceptance of Terms
+
+By installing, accessing, or using VisionFocus, you agree to be bound by these Terms. If you do not agree, you may not use the Service.
+
+## Description of Service
+
+VisionFocus is a Chrome extension that provides the following features:
+
+- Website blocking
+- Focus timer
+- Daily vision statement display
+- Premium features via paid subscription
+
+## License
+
+We grant you a limited, non-exclusive, non-transferable, revocable license to use VisionFocus for personal use in accordance with these Terms.
+
+The following activities are prohibited:
+
+- Modifying, reverse engineering, or decompiling the extension
+- Distributing, sublicensing, or selling the extension
+- Using for illegal purposes
+- Bypassing or circumventing security features
+- Removing or altering copyright notices
+
+## User Accounts and Subscriptions
+
+### Free Version
+
+The free version of VisionFocus is available without registration.
+
+### Premium Subscription
+
+- Premium features require a paid subscription (**$1.99/month**)
+- Payments are processed securely by Stripe through ExtensionPay
+- Subscriptions auto-renew unless cancelled
+- You can cancel at any time from the extension settings
+- Refunds are subject to the refund policy below
+
+### Refund Policy
+
+- Full refunds are available within 7 days of initial purchase
+- Refunds are not available for renewed subscription periods
+- To request a refund, contact us via GitHub Issues or email
+
+## User Responsibilities
+
+You are responsible for:
+
+- Maintaining the security of your Chrome browser profile
+- All activities conducted through your installation
+- Compliance with applicable laws and regulations
+- Backing up data you wish to keep (all data is stored locally)
+
+## Privacy
+
+Your use of VisionFocus is also governed by our [Privacy Policy](/en/legal/privacy/). Please review it to understand how your information is handled.
+
+## Data and Content
+
+### Your Data
+
+- Blocked sites, timers, and vision statements are all stored on your device
+- You retain all rights to your own data
+- We do not claim ownership of any content you create using the extension
+- Uninstalling the extension will delete all local data
+
+### Backups
+
+Since all data is stored locally, you are responsible for backing up any important information. We are not liable for data loss.
+
+## Changes to Service
+
+We reserve the right to:
+
+- Modify or discontinue the service (or any part of it) at any time
+- Change premium subscription pricing with 30 days' notice
+- Update and improve features
+- Enforce these Terms at our discretion
+
+For significant changes, we will notify you by:
+
+- Extension update notifications
+- Email notification (premium members only)
+- Updates to this page
+
+## Disclaimer of Warranties
+
+VisionFocus is provided "AS IS" and "AS AVAILABLE" without warranties of any kind, express or implied, including:
+
+- Merchantability
+- Fitness for a particular purpose
+- Non-infringement
+- Uninterrupted or error-free operation
+
+We do not warrant that:
+
+- The extension will meet your requirements
+- It will always be available
+- All errors will be corrected
+- It will be compatible with future Chrome versions
+
+## Limitation of Liability
+
+To the maximum extent permitted by applicable law, machina.gg and its affiliates shall not be liable for:
+
+- Indirect, incidental, special, consequential, or punitive damages
+- Loss of profits, revenue, data, or opportunities
+- Damages arising from use or inability to use the service
+- Any claims related to website blocking failures or timer accuracy
+
+Our total liability shall not exceed the amount you paid for the Service in the 12 months preceding the claim (maximum $23.88; $0 for free users).
+
+## Indemnification
+
+You agree to indemnify and hold harmless machina.gg from any claims, damages, losses, and expenses (including legal fees) arising from:
+
+- Your use of the extension
+- Your violation of these Terms
+- Your infringement of third-party rights
+- Content you transmit through the extension
+
+## Termination
+
+We may immediately suspend or terminate your access to VisionFocus for any reason without notice or liability, including:
+
+- Violation of these Terms
+- Fraudulent or illegal activity
+- Request from law enforcement
+
+Upon termination:
+
+- Your license to use the extension immediately expires
+- You must uninstall the extension
+- Your premium subscription will be cancelled (refunds subject to refund policy)
+
+## Governing Law
+
+These Terms shall be governed by the laws of Japan, without regard to conflict of law provisions.
+
+## Dispute Resolution
+
+Disputes relating to these Terms or the service shall be resolved as follows:
+
+1. Good faith negotiation
+2. Binding arbitration if negotiation fails
+3. Small claims court (where applicable)
+
+## Intellectual Property
+
+VisionFocus and all associated trademarks, logos, and content are the property of machina.gg. All rights reserved.
+
+You may not use our trademarks or brand without prior written permission.
+
+## Severability
+
+If any provision of these Terms is found to be invalid or unenforceable, the remaining provisions shall continue in full force and effect.
+
+## Entire Agreement
+
+These Terms, together with the Privacy Policy, constitute the entire agreement between you and machina.gg regarding your use of VisionFocus.
+
+## Changes to Terms
+
+We reserve the right to modify these Terms at any time. For significant changes, we will notify you by:
+
+- Updating the "Last updated" date
+- In-extension notifications
+- Email notification (premium members only)
+
+Your continued use of the extension following any changes constitutes your acceptance of the revised Terms.
+
+## Contact Us
+
+For questions about these Terms:
+
+- GitHub Issues: [https://github.com/machina-gg/vision-focus/issues](https://github.com/machina-gg/vision-focus/issues)
+- Email: legal@machina.gg
+
+## Summary
+
+Please use VisionFocus lawfully and appropriately. We provide the service "as is" and may change or discontinue it at any time. The premium subscription is $1.99/month with a 7-day refund policy. Data is stored locally and backups are your responsibility.

--- a/src/content/docs/en/vision-focus.mdx
+++ b/src/content/docs/en/vision-focus.mdx
@@ -1,0 +1,84 @@
+---
+title: VisionFocus
+description: A Chrome extension that boosts focus and protects your eyes. Block websites, set timers, and write daily vision statements to boost productivity.
+template: splash
+prev: false
+next: false
+---
+
+import ProductNav from "../../../components/shared/ProductNav.astro";
+import HeroSection from "../../../components/lp/HeroSection.astro";
+import FeatureGrid from "../../../components/lp/FeatureGrid.astro";
+import FeatureCard from "../../../components/lp/FeatureCard.astro";
+import DownloadButtons from "../../../components/lp/DownloadButtons.astro";
+import VisionFocusPricing from "../../../components/lp/VisionFocusPricing.astro";
+
+<ProductNav
+  productName="VisionFocus"
+  links={[
+    { label: "Features", href: "#features" },
+    { label: "Pricing", href: "#pricing" },
+    { label: "Docs", href: "/en/docs/vision-focus/getting-started/" },
+    {
+      label: "Install",
+      href: "https://chrome.google.com/webstore",
+      isExternal: true,
+      isPrimary: true,
+    },
+  ]}
+/>
+
+<HeroSection
+  title="Focus, freely."
+  subtitle="VisionFocus is a Chrome extension combining website blocking, timers, and daily vision statements. Your companion for protecting focus, caring for your eyes, and achieving your daily goals."
+  eyebrow="Chrome Extension"
+>
+  <DownloadButtons
+    links={[
+      {
+        label: "Chrome Web Store",
+        href: "https://chrome.google.com/webstore",
+        type: "chrome",
+      },
+      {
+        label: "Read Docs",
+        href: "/en/docs/vision-focus/getting-started/",
+        type: "direct",
+      },
+    ]}
+  />
+</HeroSection>
+
+<section id="features" class="lp-section">
+  <p class="lp-section-heading">Features</p>
+  <h2 class="lp-section-title">4 features to protect your focus</h2>
+
+  <FeatureGrid>
+    <FeatureCard
+      title="Website Blocking"
+      description="Block distracting sites with one click. Build your personal focus environment with custom lists."
+      icon="block"
+      href="/en/docs/vision-focus/blocking-websites/"
+    />
+    <FeatureCard
+      title="20-20-20 Timer"
+      description="Reduce eye strain with regular break reminders. Scientifically control your screen time."
+      icon="timer"
+      href="/en/docs/vision-focus/timers/"
+    />
+    <FeatureCard
+      title="Daily Vision"
+      description="Write down today's goals and see them while browsing. Stay motivated and keep moving toward your goals."
+      icon="vision"
+      href="/en/docs/vision-focus/vision-statements/"
+    />
+    <FeatureCard
+      title="Privacy First"
+      description="All data stored locally. Zero data sent to external servers. Use with peace of mind."
+      icon="privacy"
+      href="/en/docs/vision-focus/faq/"
+    />
+  </FeatureGrid>
+</section>
+
+<VisionFocusPricing />

--- a/src/content/docs/en/vision-focus/changelog.mdx
+++ b/src/content/docs/en/vision-focus/changelog.mdx
@@ -1,0 +1,72 @@
+---
+title: Release Notes
+description: Version history and release notes for VisionFocus
+template: splash
+prev: false
+next: false
+---
+
+import ChangelogEntry from "../../../../components/changelog/ChangelogEntry.astro";
+
+<ChangelogEntry version="1.2.0" date={new Date('2026-02-10')}>
+
+#### Added
+
+- **Schedule Blocking**: Set blocking schedules by day of week and time of day
+- **Focus Session Stats**: View weekly and monthly focus time reports in the popup
+- **Vision Templates**: Added preset templates for daily vision input (goals, gratitude, thought of the day)
+
+#### Fixed
+
+- Fixed an issue where timer completion notifications sometimes appeared twice
+- Fixed an issue where vision text was hard to read on the block page in dark mode
+- Fixed an issue where the service worker could stop after long idle periods, disabling blocking
+
+</ChangelogEntry>
+
+<ChangelogEntry version="1.1.0" date={new Date('2025-12-01')}>
+
+#### Added
+
+- **20-20-20 Rule Reminder**: Eye break feature that notifies you to look 20 feet away for 20 seconds every 20 minutes
+- **Temporary Allow**: Feature to temporarily unblock a blocked site for a specified duration (5, 15, or 30 minutes)
+- **Custom Block Page**: Customize the background color and message of the block page
+
+#### Fixed
+
+- Fixed an issue where block rules using wildcards (`*.example.com`) did not work correctly
+- Fixed an issue where the remaining timer time reset if the browser was restarted during a timer session
+
+#### Removed
+
+- Removed legacy settings format (v0.x) migration processing (only updates from v1.0.0 and later are supported)
+
+</ChangelogEntry>
+
+<ChangelogEntry version="1.0.0" date={new Date('2025-09-15')}>
+
+#### Added
+
+- **Website Blocking**: Block sites registered in custom lists (free plan supports up to 10 sites)
+- **Focus Timer**: Pomodoro-style focus and break timer (25 min focus / 5 min break)
+- **Daily Vision Statement**: Display today's goals on the block page to maintain motivation
+- **Privacy-First Design**: All data stored locally with no transmission to external servers
+- **Premium Plan**: Unlimited blocking, advanced timer options, multiple vision statements ($1.99/mo)
+
+</ChangelogEntry>
+
+<ChangelogEntry version="0.9.0" date={new Date('2025-08-01')}>
+
+#### Added
+
+- Beta release
+- Basic website blocking functionality
+- Simple timer (countdown only)
+- Daily vision input field (1 entry)
+
+#### Fixed
+
+- Fixed an issue where the extension icon was not displayed in Chrome 127 and later
+- Fixed an issue where content script injection failed on some sites
+
+</ChangelogEntry>


### PR DESCRIPTION
## Summary

- `/en/` で英語版トップページ（Hub）が表示されるよう `en/index.mdx` を新規作成
- `/en/vision-focus/` で英語版 VisionFocus LP が表示されるよう `en/vision-focus.mdx` を新規作成
- `/en/vision-focus/changelog/` で英語版リリースノートが表示されるよう `en/vision-focus/changelog.mdx` を新規作成
- `/en/legal/privacy/` `/en/legal/terms/` で英語版 Legal ページが表示されるよう各 `.md` ファイルを新規作成
- `VisionFocusPricing` コンポーネントに `Astro.currentLocale` による日英翻訳辞書を実装
- `ProductCard` コンポーネントに `ctaLabel` prop を追加（英語版で "Explore" を表示）

## Test plan

- [ ] `astro build` が正常に完了すること（CI 確認）
- [ ] `/en/index.html` が生成されること
- [ ] `/en/vision-focus/index.html` が生成されること
- [ ] `/en/vision-focus/changelog/index.html` が生成されること
- [ ] `/en/legal/privacy/index.html` が生成されること
- [ ] `/en/legal/terms/index.html` が生成されること
- [ ] 英語版 LP の Pricing セクションが英語テキストで表示されること
- [ ] 日本語版（`/vision-focus/`）の Pricing セクションが引き続き日本語で表示されること
- [ ] 全リンクに `/en/` プレフィックスが付いていること

Closes #52
Parent: #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)