### PR TITLE
chore: setup-framework 生成物を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# setup-framework.sh（trillion-game-startup）が生成するファイル
+.claude/commands/project/
+.claude/tmp/
+CLAUDE.md
+CLAUDE_CODE_REFERENCE.md


### PR DESCRIPTION
## 概要

`setup-framework.sh`（trillion-game-startup）が生成するファイルを `.gitignore` に追加する。

Closes #83

## 背景

対象 4 パスはいずれもローカルに実在するが未追跡の状態で、`git status` のノイズになるうえ `git add -A` で誤コミットされる恐れがあった。

| パス | 内容 |
| --- | --- |
| `.claude/commands/project/` | 生成コマンド定義 9 ファイル |
| `.claude/tmp/` | 一時ディレクトリ |
| `CLAUDE.md` | 生成物（216 行） |
| `CLAUDE_CODE_REFERENCE.md` | 生成物（78 行） |

同内容は `vision-focus` の `.gitignore` に既にコミット済みで、リポジトリ間の慣習とも揃う。

## 検証

`git status --ignored` で 4 パスが ignored に分類されること、および追跡中ファイルが新たに除外されていないことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkTfPzswRSbbjswvmqxvt4