### PR TITLE
fix: 記事目次コンポーネントをロケール対応させる

### DIFF
--- a/src/components/articles/ArticleToc.astro
+++ b/src/components/articles/ArticleToc.astro
@@ -1,11 +1,21 @@
 ---
 // 記事ページの目次コンポーネント（Starlight の「On this page」相当）
 // article-body 内の h2/h3 見出しからクライアントサイドで自動生成する
+
+// ロケール判定
+const locale = Astro.currentLocale ?? 'ja';
+
+// 翻訳辞書
+const fallback = { tocTitle: '目次', tocLabel: '目次' };
+const t = {
+  ja: fallback,
+  en: { tocTitle: 'On this page', tocLabel: 'Table of contents' },
+}[locale] ?? fallback;
 ---
 
-<nav class="article-toc" aria-label="目次" data-article-toc>
+<nav class="article-toc" aria-label={t.tocLabel} data-article-toc>
   <div class="article-toc-inner">
-    <p class="article-toc-title">目次</p>
+    <p class="article-toc-title">{t.tocTitle}</p>
     <ul class="article-toc-list" data-toc-list></ul>
   </div>
 </nav>


### PR DESCRIPTION
## 概要

英語記事ページで目次の見出しと `aria-label` が日本語の「目次」のまま表示されていた問題を修正する。

Closes #85

## 原因

Issue #35 の i18n 対応で、他のコンポーネント（Search / Footer / ArticleNav / ArticleCta / ArticleList / VisionFocusPricing）にはロケール判定と翻訳辞書が入ったが、`ArticleToc.astro` だけ対応から漏れていた。

## 変更内容

`src/components/articles/ArticleToc.astro` に `Astro.currentLocale` によるロケール判定と翻訳辞書を追加。イディオムは既存の `ArticleNav.astro` に合わせた。

| キー | ja | en |
| --- | --- | --- |
| `tocTitle`（表示見出し） | 目次 | On this page |
| `tocLabel`（`aria-label`） | 目次 | Table of contents |

`aria-label` は表示見出しと役割が異なるため別キーとし、英語では慣用的な "Table of contents" を採用した。

## 検証

`pnpm build`（42 ページ）成功。生成された HTML を直接確認済み。

**英語** — `dist/en/articles/science-of-digital-breaks/index.html`
```
article-toc-title ...>On this page
aria-label="Table of contents" data-article-toc
```

**日本語** — `dist/articles/deep-work-introduction/index.html`
```
article-toc-title ...>目次
aria-label="目次" data-article-toc
```

## 関連

Issue #35 のスコープ 6（記事ページの言語切替リンク）は未実装のため #86 として切り出した。本 PR のマージをもって #35 はクローズ予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkTfPzswRSbbjswvmqxvt4