### PR TITLE
ci: PR トリガーのビルド検証ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [develop]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # pnpm のバージョンは package.json の packageManager から解決される
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+  issue-check:
+    name: Issue Check
+    # push では PR 本文が存在しないため PR のときだけ実行する
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check issue linking
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          # Closes #N, Fixes #N, Resolves #N のいずれかがあるか
+          if echo "$PR_BODY" | grep -qiE "(closes|fixes|resolves)\s+#[0-9]+"; then
+            echo "=== Issue 紐づけチェック OK ==="
+            exit 0
+          fi
+
+          # override:no-issue ラベルがあればスキップ
+          if echo "$PR_LABELS" | grep -q "override:no-issue"; then
+            echo ""
+            echo "::notice::override:no-issue ラベルにより Issue 紐づけチェックをスキップ"
+            exit 0
+          fi
+
+          echo ""
+          echo "::error::PR 本文に Issue 紐づけ（Closes #N）がありません。"
+          echo "PR 本文に 'Closes #N' を追加してください。"
+          echo "Issue がない場合は先に Issue を作成してください。"
+          echo "やむを得ない場合は PR に 'override:no-issue' ラベルを付けてください。"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [develop]
 
+# 最小権限。ソースの読み取りのみで足りる
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## 概要

PR 時にビルドが通るかを自動検証するワークフローを追加する。

Closes #90

## 背景

直近の PR #82 / #84 / #87 はいずれも `no checks reported` の状態でマージされており、ビルド検証がローカル実行に依存していた。

## 変更内容

`.github/workflows/ci.yml` を新規追加。

| ジョブ | 内容 |
| --- | --- |
| `build` | pnpm で `install --frozen-lockfile` → `build` |
| `issue-check` | PR 本文の Issue 紐づけ（`Closes #N`）を検証。`override:no-issue` ラベルで回避可能 |

- トリガーは `pull_request: [main, develop]` と `push: [develop]`
- pnpm のバージョンは #81 で追加した `packageManager` フィールドから解決させるため、`pnpm/action-setup` に `version` は指定しない
- `issue-check` は push 時に PR 本文が存在しないため `if: github.event_name == 'pull_request'` で PR 限定にした
- 実装は trillion-game の `pr-check.yml` に合わせ、`override:no-issue` の回避手段も同一にした

## 検証

- Prettier のフォーマットチェック通過
- YAML としてパース可能なこと、`jobs` と `on` の構造を確認
- 本 PR 自体がこのワークフローの初回実行になる（`Closes #90` を含むため issue-check も通るはず）

## スコープ外

別 Issue として切り出す。

- Prettier のフォーマットチェック — 既存 md / yml 13 ファイルが現状通らないため、一括整形とセットで対応する
- 型チェック（`astro check`） — `@astrojs/check` と `typescript` の依存追加が必要
- `claude-review.yml` の `startup_failure` — リポジトリ Secret の設定が必要でコード変更では解決しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkTfPzswRSbbjswvmqxvt4